### PR TITLE
Adds swift 4.0 support to the framework

### DIFF
--- a/Sources/Extensions/UIDeviceExtensions.swift
+++ b/Sources/Extensions/UIDeviceExtensions.swift
@@ -30,7 +30,11 @@ extension UIDevice {
     var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
         if #available(iOS 11.0, *) {
             if let space = try? URL(fileURLWithPath: NSHomeDirectory() as String).resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForImportantUsageKey]).volumeAvailableCapacityForImportantUsage {
-                return space
+                #if swift(>=5)
+                    return space
+                #else
+                    return space ?? 0
+                #endif
             } else {
                 return 0
             }


### PR DESCRIPTION
The following PR will fix the issue with 
`if let space = try? URL(fileURLWithPath: NSHomeDirectory() as String).resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForImportantUsageKey]).volumeAvailableCapacityForImportantUsage` is still an resolving into an optional in swift 4.2 whereas swift 5 it's a normal Uint64