### PR TITLE
fix: save to desktop not working when Diagnostics directory not found

### DIFF
--- a/Sources/DiagnosticsReport.swift
+++ b/Sources/DiagnosticsReport.swift
@@ -30,7 +30,18 @@ public extension DiagnosticsReport {
         let simulatorPath = (NSSearchPathForDirectoriesInDomains(.desktopDirectory, .userDomainMask, true) as [String]).first!
         let simulatorPathComponents = URL(string: simulatorPath)!.pathComponents.prefix(3).filter { $0 != "/" }
         let userPath = simulatorPathComponents.joined(separator: "/")
-        let path = "/\(userPath)/Desktop/Diagnostics/\(filename)"
+        let path = "/\(userPath)/Desktop"
+        let directoryPath = "\(path)/Diagnostics"
+        do {
+            try FileManager.default.createDirectory(atPath: directoryPath, withIntermediateDirectories: false, attributes: nil)
+            save(path: "\(directoryPath)/\(filename)")
+        } catch {
+            save(path: "\(path)/\(filename)")
+        }
+    }
+    
+    
+    func save(path: String) {
         guard FileManager.default.createFile(atPath: path, contents: data, attributes: [FileAttributeKey.type: mimeType.rawValue]) else {
             // swiftlint:disable nslog_prohibited
             print("Diagnostics Report could not be saved to: \(path)")

--- a/Sources/DiagnosticsReport.swift
+++ b/Sources/DiagnosticsReport.swift
@@ -25,6 +25,13 @@ public struct DiagnosticsReport {
 }
 
 public extension DiagnosticsReport {
+    
+    private func isDirectory(atPath path: String) -> Bool {
+        var directory: ObjCBool = true
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &directory)
+        return exists && directory.boolValue
+    }
+    
     /// This method can be used for debugging purposes to save the report to a `Diagnostics` folder on desktop.
     func saveToDesktop() {
         let simulatorPath = (NSSearchPathForDirectoriesInDomains(.desktopDirectory, .userDomainMask, true) as [String]).first!
@@ -32,6 +39,11 @@ public extension DiagnosticsReport {
         let userPath = simulatorPathComponents.joined(separator: "/")
         let path = "/\(userPath)/Desktop"
         let directoryPath = "\(path)/Diagnostics"
+        
+        if isDirectory(atPath: directoryPath) {
+            save(path: "\(directoryPath)/\(filename)")
+            return
+        }
         do {
             try FileManager.default.createDirectory(atPath: directoryPath, withIntermediateDirectories: false, attributes: nil)
             save(path: "\(directoryPath)/\(filename)")
@@ -39,7 +51,6 @@ public extension DiagnosticsReport {
             save(path: "\(path)/\(filename)")
         }
     }
-    
     
     func save(path: String) {
         guard FileManager.default.createFile(atPath: path, contents: data, attributes: [FileAttributeKey.type: mimeType.rawValue]) else {


### PR DESCRIPTION
The following PR fixes the an issue where the Diagnostics file is not created, since there is no Directory called `Diagnostics` in the desktop