### PR TITLE
Forward the output of the DiagnosticsLogger to not disable default logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Next
+- Make sure that the DiagnosticsLogger is not running during tests 
 
 ### 1.1.0
 - Added an `HTMLFormatting` type for custom formatting HTML inside reports

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -24,7 +24,7 @@ public final class DiagnosticsLogger {
     private let trimSize: ByteCountFormatter.Units.Bytes = 100 * 1024 // 100 KB
 
     private var isRunningTests: Bool {
-        return ProcessInfo.processInfo.arguments.contains("-UNITTEST")
+        return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 
     private lazy var formatter: DateFormatter = {


### PR DESCRIPTION
It turned out that the `Pipe` we were using to capture any `STDOUT_FILENO` output was also capturing xcodebuild output. This caused our Fastlane setup to fail. We had to forward the output to an outpipe to make sure original logs show up again.

This is to make sure that the logs are showing up in the Xcode console while debugging but as well for runs in the terminal when testing.

More info in this blog post: https://medium.com/@thesaadismail/eavesdropping-on-swifts-print-statements-57f0215efb42