### PR TITLE
Check available disk space before writing to the log

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Next
+- Make sure to check whether there's enough space left to save new logs (#37)
 
 ### 1.2.0
 - Forward the output of the DiagnosticsLogger to not disable default logging

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -143,6 +143,9 @@ extension DiagnosticsLogger {
                 return assertionFailure()
         }
 
+        // Make sure we have more then 500MB space left
+        guard UIDevice.current.freeDiskSpaceInBytes > (500 * 1024) else { return }
+
         fileHandle.seekToEndOfFile()
         fileHandle.write(data)
         logSize += Int64(data.count)

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -149,7 +149,7 @@ extension DiagnosticsLogger {
                 return assertionFailure()
         }
 
-        // Make sure we enough disk space left. This prevents a crash due to a lack of space.
+        // Make sure we have enough disk space left. This prevents a crash due to a lack of space.
         guard UIDevice.current.freeDiskSpaceInBytes > minimumRequiredDiskSpace else { return }
 
         fileHandle.seekToEndOfFile()

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -23,6 +23,7 @@ public final class DiagnosticsLogger {
     private var logSize: ByteCountFormatter.Units.Bytes!
     private let maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024 // 2 MB
     private let trimSize: ByteCountFormatter.Units.Bytes = 100 * 1024 // 100 KB
+    private let minimumRequiredDiskSpace: ByteCountFormatter.Units.Bytes = 500 * 1024 * 1024 // 500 MB
 
     private var isRunningTests: Bool {
         return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
@@ -143,8 +144,8 @@ extension DiagnosticsLogger {
                 return assertionFailure()
         }
 
-        // Make sure we have more than 500MB space left
-        guard UIDevice.current.freeDiskSpaceInBytes > (500 * 1024) else { return }
+        // Make sure we enough disk space left. This prevents a crash due to a lack of space.
+        guard UIDevice.current.freeDiskSpaceInBytes > minimumRequiredDiskSpace else { return }
 
         fileHandle.seekToEndOfFile()
         fileHandle.write(data)

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -143,7 +143,7 @@ extension DiagnosticsLogger {
                 return assertionFailure()
         }
 
-        // Make sure we have more then 500MB space left
+        // Make sure we have more than 500MB space left
         guard UIDevice.current.freeDiskSpaceInBytes > (500 * 1024) else { return }
 
         fileHandle.seekToEndOfFile()


### PR DESCRIPTION
This fixes crashes happening for users that don't have enough space left on their device.

Fixes #37