### PR TITLE
min deployment target iOS 10.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Next
+- Support for iOS 10.0. #42
 
 ### 1.2.0
 - Forward the output of the DiagnosticsLogger to not disable default logging

--- a/Diagnostics.podspec
+++ b/Diagnostics.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/WeTransfer/Diagnostics.git', :tag => spec.version.to_s }
   spec.social_media_url = 'https://twitter.com/WeTransfer'
 
-  spec.ios.deployment_target = '11.0'
+  spec.ios.deployment_target = '10.0'
   spec.source_files     = 'Sources/**/*'
   spec.swift_version    = '5.1'
 end

--- a/Diagnostics.xcodeproj/project.pbxproj
+++ b/Diagnostics.xcodeproj/project.pbxproj
@@ -512,7 +512,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Diagnostics/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -540,7 +540,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Diagnostics/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/Reporters/UserDefaultsReporter.swift
+++ b/Sources/Reporters/UserDefaultsReporter.swift
@@ -29,7 +29,13 @@ extension UserDefaultsReporter: HTMLFormatting {
 
 private extension Dictionary where Key == String, Value == Any {
     var jsonRepresentation: String? {
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: jsonCompatible, options: [.prettyPrinted, .sortedKeys, .fragmentsAllowed]) else { return nil }
+        let options: JSONSerialization.WritingOptions
+        if #available(iOS 11.0, *) {
+            options = [.prettyPrinted, .sortedKeys, .fragmentsAllowed]
+        } else {
+            options = [.prettyPrinted, .fragmentsAllowed]
+        }
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: jsonCompatible, options: options) else { return nil }
         return String(data: jsonData, encoding: .utf8)
     }
 


### PR DESCRIPTION
Changelog
1. make minimum deployment to iOS 10.0 to podspec.
2. Json serialization sortedKeys options remove for iOS 10.

Fixes #42 