### PR TITLE
Changed log times to use 24H clock.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Next
+- Changed log times to use 24H clock (#40)
 - Support for iOS 10.0. #42
 
 ### 1.2.0

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -30,7 +30,7 @@ public final class DiagnosticsLogger {
 
     private lazy var formatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         formatter.locale = Locale(identifier: "en_US")
         formatter.timeZone = TimeZone(identifier: "GMT")!
         return formatter


### PR DESCRIPTION
There is currently no indication of AM or PM in the log times, so I changed the the logger's date formatter to use a 24H clock.