### PR TITLE
Add charset utf-8 to html head

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### Next
+- Add charset utf-8 to html head
 
 ### 1.3.0
 - Make sure to check whether there's enough space left to save new logs (#37)

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -82,6 +82,7 @@ extension DiagnosticsReporter {
         var html = "<head>"
         html += "<title>\(Bundle.appName) - Diagnostics Report</title>"
         html += style()
+        html += "<meta charset=\"utf-8\">"
         html += "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
         html += "</head>"
         return html


### PR DESCRIPTION
Non-ascii characters in HTML output were not displayed correctly in Safari. Specifying charset to utf-8 in HTML meta tag will fix this issue.