### PR TITLE
Encode HTML in final report

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,11 @@
+### Next Version
+- Added HTML encoding to entities in logs when final report is created ([#51](https://github.com/WeTransfer/Diagnostics/issues/51))
+
 ### 1.5.0
 - Change the order of reported sessions ([#54](https://github.com/WeTransfer/Diagnostics/issues/54)) via @AvdLee
 - Merge release 1.4.0 into master ([#53](https://github.com/WeTransfer/Diagnostics/pull/53))
 
 ### 1.4.0
-
 - Migrate to Bitrise & Danger-Swift ([#52](https://github.com/WeTransfer/Diagnostics/pull/52)) via @AvdLee
 - Add charset utf-8 to html head ([#50](https://github.com/WeTransfer/Diagnostics/pull/50)) via @AvdLee
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,3 @@
-### Next Version
-- Added HTML encoding to entities in logs when final report is created ([#51](https://github.com/WeTransfer/Diagnostics/issues/51))
-
 ### 1.5.0
 - Change the order of reported sessions ([#54](https://github.com/WeTransfer/Diagnostics/issues/54)) via @AvdLee
 - Merge release 1.4.0 into master ([#53](https://github.com/WeTransfer/Diagnostics/pull/53))

--- a/Diagnostics.xcodeproj/project.pbxproj
+++ b/Diagnostics.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		416CE0182406D85F00698E0A /* HTMLEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416CE0172406D85F00698E0A /* HTMLEncoding.swift */; };
 		500B2756239524E100C304D4 /* Diagnostics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 500B274C239524E100C304D4 /* Diagnostics.framework */; };
 		500B275D239524E100C304D4 /* Diagnostics.h in Headers */ = {isa = PBXBuildFile; fileRef = 500B274F239524E100C304D4 /* Diagnostics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		500B276823953E4100C304D4 /* DiagnosticsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500B276723953E4100C304D4 /* DiagnosticsReporter.swift */; };
@@ -44,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		416CE0172406D85F00698E0A /* HTMLEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLEncoding.swift; sourceTree = "<group>"; };
 		500B274C239524E100C304D4 /* Diagnostics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Diagnostics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		500B274F239524E100C304D4 /* Diagnostics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Diagnostics.h; sourceTree = "<group>"; };
 		500B2750239524E100C304D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				500B27A92395520300C304D4 /* DiagnosticsReport.swift */,
 				505000ED239FA22400EADD27 /* DiagnosticsReportFilter.swift */,
 				500B276723953E4100C304D4 /* DiagnosticsReporter.swift */,
+				416CE0172406D85F00698E0A /* HTMLEncoding.swift */,
 				500B27AF2395551200C304D4 /* HTMLGenerating.swift */,
 				500B27BD23956A8A00C304D4 /* style.css */,
 			);
@@ -349,6 +352,7 @@
 				500B27A22395413200C304D4 /* MFMailComposeVCExtensions.swift in Sources */,
 				505000EE239FA22400EADD27 /* DiagnosticsReportFilter.swift in Sources */,
 				500B27C62395967200C304D4 /* LogsReporter.swift in Sources */,
+				416CE0182406D85F00698E0A /* HTMLEncoding.swift in Sources */,
 				505000F0239FA2A300EADD27 /* DiagnosticsChapter.swift in Sources */,
 				500B27C0239571FB00C304D4 /* UIDeviceExtensions.swift in Sources */,
 			);

--- a/Sources/HTMLEncoding.swift
+++ b/Sources/HTMLEncoding.swift
@@ -16,7 +16,7 @@ extension String: HTMLEncoding {
     
     /// Encodes entities to be displayed correctly in the final HTML report.
     func addingHTMLEncoding() -> HTML {
-        return self.replacingOccurrences(of: "<", with: "&lt;")
+        return replacingOccurrences(of: "<", with: "&lt;")
                    .replacingOccurrences(of: ">", with: "&gt;")
     }
 }

--- a/Sources/HTMLEncoding.swift
+++ b/Sources/HTMLEncoding.swift
@@ -1,0 +1,22 @@
+//
+//  HTMLEncoding.swift
+//  Diagnostics
+//
+//  Created by David Steppenbeck on 2020/02/26.
+//  Copyright © 2020 WeTransfer. All rights reserved.
+//
+
+import Foundation
+
+public protocol HTMLEncoding {
+    func addingHTMLEncoding() -> HTML
+}
+
+extension String: HTMLEncoding {
+    
+    /// Encodes entities to be displayed correctly in the final HTML report.
+    public func addingHTMLEncoding() -> HTML {
+        return self.replacingOccurrences(of: "<", with: "&lt;")
+                   .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}

--- a/Sources/HTMLEncoding.swift
+++ b/Sources/HTMLEncoding.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol HTMLEncoding {
+protocol HTMLEncoding {
     func addingHTMLEncoding() -> HTML
 }
 

--- a/Sources/HTMLEncoding.swift
+++ b/Sources/HTMLEncoding.swift
@@ -15,7 +15,7 @@ public protocol HTMLEncoding {
 extension String: HTMLEncoding {
     
     /// Encodes entities to be displayed correctly in the final HTML report.
-    public func addingHTMLEncoding() -> HTML {
+    func addingHTMLEncoding() -> HTML {
         return self.replacingOccurrences(of: "<", with: "&lt;")
                    .replacingOccurrences(of: ">", with: "&gt;")
     }

--- a/Sources/Reporters/LogsReporter.swift
+++ b/Sources/Reporters/LogsReporter.swift
@@ -17,7 +17,7 @@ struct LogsReporter: DiagnosticsReporting {
             return "Parsing the log failed"
         }
 
-        let sessions = logs.components(separatedBy: "\n\n---\n\n")
+        let sessions = logs.addingHTMLEncoding().components(separatedBy: "\n\n---\n\n")
         return sessions.reversed().joined(separator: "\n\n---\n\n")
     }
 


### PR DESCRIPTION
Adds HTML encoding to logged strings when final report is created.

Fixes #51 