### PR TITLE
Merge release 1.6.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### 1.6.0
+- Include device product names ([#60](https://github.com/WeTransfer/Diagnostics/issues/60))
+- Encode Logging for HTML so object descriptions are visible ([#51](https://github.com/WeTransfer/Diagnostics/issues/51))
+- Trivial title fix. ([#59](https://github.com/WeTransfer/Diagnostics/pull/59))
+- Merge release 1.5.0 into master ([#56](https://github.com/WeTransfer/Diagnostics/pull/56))
+
 ### 1.5.0
 - Change the order of reported sessions ([#54](https://github.com/WeTransfer/Diagnostics/issues/54)) via @AvdLee
 - Merge release 1.4.0 into master ([#53](https://github.com/WeTransfer/Diagnostics/pull/53))

--- a/Diagnostics.podspec
+++ b/Diagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Diagnostics'
-  spec.version          = '1.5.0'
+  spec.version          = '1.6.0'
   spec.summary          = 'Create easy Diagnostics Reports and let user send them to your support team.'
   spec.description      = 'Diagnostics is a library written in Swift which makes it really easy to share Diagnostics Reports to your support team.'
 


### PR DESCRIPTION
Containing all the changes for our [**1.6.0 Release**](https://github.com/WeTransfer/Diagnostics/releases/tag/1.6.0).