### PR TITLE
Fix memory leak in readInBackgroundAndNotify method

### DIFF
--- a/Example/Diagnostics-Example.xcodeproj/xcshareddata/xcschemes/Diagnostics-Example.xcscheme
+++ b/Example/Diagnostics-Example.xcodeproj/xcshareddata/xcschemes/Diagnostics-Example.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "500B277323953F8C00C304D4"
+               BuildableName = "Diagnostics-Example.app"
+               BlueprintName = "Diagnostics-Example"
+               ReferencedContainer = "container:Diagnostics-Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "500B277323953F8C00C304D4"
+            BuildableName = "Diagnostics-Example.app"
+            BlueprintName = "Diagnostics-Example"
+            ReferencedContainer = "container:Diagnostics-Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "500B277323953F8C00C304D4"
+            BuildableName = "Diagnostics-Example.app"
+            BlueprintName = "Diagnostics-Example"
+            ReferencedContainer = "container:Diagnostics-Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -87,7 +87,7 @@ extension DiagnosticsLogger {
     /// Reads the log and converts it to a `Data` object.
     func readLog() -> Data? {
         guard isSetup else {
-            assertionFailure()
+            assertionFailure("Trying to read the log while not set up")
             return nil
         }
 
@@ -135,7 +135,7 @@ extension DiagnosticsLogger {
     }
 
     private func log(message: String, file: String = #file, function: String = #function, line: UInt = #line) {
-        guard isSetup else { return assertionFailure() }
+        guard isSetup else { return assertionFailure("Trying to log a message while not set up") }
 
         self.queue.async { [unowned self] in
             let date = self.formatter.string(from: Date())
@@ -149,7 +149,7 @@ extension DiagnosticsLogger {
         guard
             let data = output.data(using: .utf8),
             let fileHandle = logFileHandle else {
-                return assertionFailure()
+                return assertionFailure("Missing file handle or invalid output logged")
         }
 
         // Make sure we have enough disk space left. This prevents a crash due to a lack of space.
@@ -168,7 +168,7 @@ extension DiagnosticsLogger {
             var data = try? Data(contentsOf: self.logFileLocation, options: .mappedIfSafe),
             !data.isEmpty,
             let newline = "\n".data(using: .utf8) else {
-                return assertionFailure()
+                return assertionFailure("Trimming the current log file failed")
         }
 
         var position: Int = 0
@@ -181,7 +181,7 @@ extension DiagnosticsLogger {
         data.removeSubrange(0 ..< position)
 
         guard (try? data.write(to: logFileLocation, options: .atomic)) != nil else {
-            return assertionFailure()
+            return assertionFailure("Could not write trimmed log to target file location: \(logFileLocation)")
         }
     }
 }
@@ -212,7 +212,7 @@ private extension DiagnosticsLogger {
         outputPipe.fileHandleForWriting.write(data)
 
         guard let string = String(data: data, encoding: .utf8) else {
-            return assertionFailure()
+            return assertionFailure("Invalid data is logged")
         }
 
         string.enumerateLines(invoking: { [weak self] (line, _) in

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -15,10 +15,13 @@ public final class DiagnosticsLogger {
 
     static let standard = DiagnosticsLogger()
 
-    private lazy var location: URL = FileManager.default.documentsDirectory.appendingPathComponent("diagnostics_log.txt")
+    private lazy var logFileLocation: URL = FileManager.default.documentsDirectory.appendingPathComponent("diagnostics_log.txt")
+    private var logFileHandle: FileHandle?
+
     private let inputPipe: Pipe = Pipe()
     private let outputPipe: Pipe = Pipe()
-    private let queue: DispatchQueue = DispatchQueue(label: "com.wetransfer.diagnostics.logger", qos: .utility, target: .global(qos: .utility))
+
+    private let queue: DispatchQueue = DispatchQueue(label: "com.wetransfer.diagnostics.logger", qos: .utility, autoreleaseFrequency: .workItem, target: .global(qos: .utility))
 
     private var logSize: ByteCountFormatter.Units.Bytes!
     private let maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024 // 2 MB
@@ -88,34 +91,34 @@ extension DiagnosticsLogger {
             return nil
         }
 
-        return queue.sync { try? Data(contentsOf: location) }
+        return queue.sync { try? Data(contentsOf: logFileLocation) }
     }
 
-    /// Removes the log file.
+    /// Removes the log file. Should only be used for testing purposes.
     func deleteLogs() throws {
-        guard FileManager.default.fileExists(atPath: location.path) else { return }
-        try? FileManager.default.removeItem(atPath: location.path)
+        guard FileManager.default.fileExists(atPath: logFileLocation.path) else { return }
+        try? FileManager.default.removeItem(atPath: logFileLocation.path)
     }
 
     private func setup() throws {
-        if !FileManager.default.fileExists(atPath: location.path) {
+        if !FileManager.default.fileExists(atPath: logFileLocation.path) {
             try FileManager.default.createDirectory(atPath: FileManager.default.documentsDirectory.path, withIntermediateDirectories: true, attributes: nil)
-            guard FileManager.default.createFile(atPath: location.path, contents: nil, attributes: nil) else {
+            guard FileManager.default.createFile(atPath: logFileLocation.path, contents: nil, attributes: nil) else {
                 assertionFailure("Unable to create the log file")
                 return
             }
         }
 
-        let fileHandle = try FileHandle(forReadingFrom: location)
-        fileHandle.seekToEndOfFile()
-        logSize = Int64(fileHandle.offsetInFile)
+        logFileHandle = try FileHandle(forWritingTo: logFileLocation)
+        logFileHandle!.seekToEndOfFile()
+        logSize = Int64(logFileHandle!.offsetInFile)
         setupPipe()
         isSetup = true
         startNewSession()
     }
 
     internal func startNewSession() {
-        queue.async {
+        queue.async { [unowned self] in
             let date = self.formatter.string(from: Date())
             let appVersion = "\(Bundle.appVersion) (\(Bundle.appBuildNumber))"
             let system = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
@@ -134,7 +137,7 @@ extension DiagnosticsLogger {
     private func log(message: String, file: String = #file, function: String = #function, line: UInt = #line) {
         guard isSetup else { return assertionFailure() }
 
-        queue.async {
+        self.queue.async { [unowned self] in
             let date = self.formatter.string(from: Date())
             let file = file.split(separator: "/").last.map(String.init) ?? file
             let output = String(format: "%@ | %@:L%@ | %@\n", date, file, String(line), message)
@@ -145,7 +148,7 @@ extension DiagnosticsLogger {
     private func log(_ output: String) {
         guard
             let data = output.data(using: .utf8),
-            let fileHandle = (try? FileHandle(forWritingTo: location)) else {
+            let fileHandle = logFileHandle else {
                 return assertionFailure()
         }
 
@@ -162,7 +165,7 @@ extension DiagnosticsLogger {
         guard logSize > maximumSize else { return }
 
         guard
-            var data = try? Data(contentsOf: self.location, options: .mappedIfSafe),
+            var data = try? Data(contentsOf: self.logFileLocation, options: .mappedIfSafe),
             !data.isEmpty,
             let newline = "\n".data(using: .utf8) else {
                 return assertionFailure()
@@ -177,7 +180,7 @@ extension DiagnosticsLogger {
         logSize -= Int64(position)
         data.removeSubrange(0 ..< position)
 
-        guard (try? data.write(to: location, options: .atomic)) != nil else {
+        guard (try? data.write(to: logFileLocation, options: .atomic)) != nil else {
             return assertionFailure()
         }
     }
@@ -189,7 +192,12 @@ private extension DiagnosticsLogger {
     func setupPipe() {
         guard !isRunningTests else { return }
 
-        let pipeReadHandle = inputPipe.fileHandleForReading
+        inputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            self?.queue.async {
+                self?.handleLoggedData(data)
+            }
+        }
 
         // Copy the STDOUT file descriptor into our output pipe's file descriptor
         // So we can write the strings back to STDOUT and it shows up again in the Xcode console.
@@ -198,39 +206,18 @@ private extension DiagnosticsLogger {
         // Send all output (STDOUT and STDERR) to our `Pipe`.
         dup2(inputPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         dup2(inputPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
-
-        // Observe notifications from our input `Pipe`.
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handlePipeNotification(_:)),
-            name: FileHandle.readCompletionNotification,
-            object: pipeReadHandle
-        )
-
-        // Start asynchronously monitoring our `Pipe`.
-        pipeReadHandle.readInBackgroundAndNotify()
     }
 
-    @objc func handlePipeNotification(_ notification: Notification) {
-        defer {
-            // You have to call this again to continuously receive notifications.
-            inputPipe.fileHandleForReading.readInBackgroundAndNotify()
-        }
-
-        guard
-            let data = notification.userInfo?[NSFileHandleNotificationDataItem] as? Data,
-            let string = String(data: data, encoding: .utf8) else {
-                assertionFailure()
-                return
-        }
-
+    private func handleLoggedData(_ data: Data) {
         outputPipe.fileHandleForWriting.write(data)
 
-        queue.async {
-            string.enumerateLines(invoking: { (line, _) in
-                self.log("SYSTEM: \(line)\n")
-            })
+        guard let string = String(data: data, encoding: .utf8) else {
+            return assertionFailure()
         }
+
+        string.enumerateLines(invoking: { [weak self] (line, _) in
+            self?.log("SYSTEM: \(line)\n")
+        })
     }
 }
 


### PR DESCRIPTION
In the process of fixing #65 I've been optimizing our code a bit.

- [x] The queue is now using an autoreleasepool to make sure we release all memory correctly
- [x] Although used as a singleton we were retaining `self` quite a bit. Fixed this
- [x] We're no longer using the [readInBackgroundAndNotify](https://developer.apple.com/documentation/foundation/filehandle/1417635-readinbackgroundandnotify) method that was causing a memory leak. Instead, the `readabilityHandler` allows us to read new log values.

| Before | After |
| --- | --- |
| <img width="504" alt="Screenshot 2020-05-25 at 16 02 25" src="https://user-images.githubusercontent.com/4329185/82820236-1c01ec00-9ea2-11ea-8d14-fb70661ed943.png"> | <img width="520" alt="Screenshot 2020-05-25 at 16 02 09" src="https://user-images.githubusercontent.com/4329185/82820235-1a382880-9ea2-11ea-9580-c8892a6fee7d.png"> |




Fixes #65 