### PR TITLE
Add configuration struct (#66)

### DIFF
--- a/DiagnosticsTests/DiagnosticsReporterTests.swift
+++ b/DiagnosticsTests/DiagnosticsReporterTests.swift
@@ -13,7 +13,12 @@ final class DiagnosticsReporterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        try! DiagnosticsLogger.setup()
+        
+        let configuration = DiagnosticsConfiguration(
+            maximumSize: 1 * 1024 * 1024, // 1MB
+            maximumNumberOfSession: 10)
+        
+        try! DiagnosticsLogger.setup(configuration: configuration)
     }
 
     override class func tearDown() {

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -9,9 +9,21 @@
 import Foundation
 import UIKit
 
+
 /// A Diagnostics Logger to log messages to which will end up in the Diagnostics Report if using the default `LogsReporter`.
 /// Will keep a `.txt` log in the documents directory with the latestlogs with a max size of 2 MB.
 public final class DiagnosticsLogger {
+    
+    // Struct holding any property that we want configurable by the user
+    public struct DiagnosticsConfiguration {
+        var maximumSize: ByteCountFormatter.Units.Bytes
+        var maximumNumberOfSession : Int?
+        public init(maximumSize:ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024,
+             maximumNumberOfSession: Int? = nil){
+            self.maximumSize = maximumSize
+            self.maximumNumberOfSession = maximumNumberOfSession
+        }
+    }
 
     static let standard = DiagnosticsLogger()
 
@@ -23,8 +35,9 @@ public final class DiagnosticsLogger {
 
     private let queue: DispatchQueue = DispatchQueue(label: "com.wetransfer.diagnostics.logger", qos: .utility, autoreleaseFrequency: .workItem, target: .global(qos: .utility))
 
+    
     private var logSize: ByteCountFormatter.Units.Bytes!
-    private let maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024 // 2 MB
+    private var maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024 // 2 MB
     private let trimSize: ByteCountFormatter.Units.Bytes = 100 * 1024 // 100 KB
     private let minimumRequiredDiskSpace: ByteCountFormatter.Units.Bytes = 500 * 1024 * 1024 // 500 MB
 
@@ -42,6 +55,9 @@ public final class DiagnosticsLogger {
 
     /// Whether the logger is setup and ready to use.
     private var isSetup: Bool = false
+    
+    // Public Configuration
+    public var configuration : DiagnosticsConfiguration = DiagnosticsConfiguration()
 
     /// Whether the logger is setup and ready to use.
     public static func isSetUp() -> Bool {
@@ -50,8 +66,9 @@ public final class DiagnosticsLogger {
 
     /// Sets up the logger to be ready for usage. This needs to be called before any log messages are reported.
     /// This method also starts a new session.
-    public static func setup() throws {
+    public static func setup(configuration: DiagnosticsConfiguration = DiagnosticsConfiguration()) throws {
         try standard.setup()
+        standard.configuration = configuration
     }
 
     /// Logs the given message for the diagnostics report.

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -9,21 +9,20 @@
 import Foundation
 import UIKit
 
+// Struct holding any property that we want configurable by the user
+public struct DiagnosticsConfiguration {
+    var maximumSize: ByteCountFormatter.Units.Bytes
+    var maximumNumberOfSession: Int?
+    public init(maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024,
+                maximumNumberOfSession: Int? = nil) {
+        self.maximumSize = maximumSize
+        self.maximumNumberOfSession = maximumNumberOfSession
+    }
+}
 
 /// A Diagnostics Logger to log messages to which will end up in the Diagnostics Report if using the default `LogsReporter`.
 /// Will keep a `.txt` log in the documents directory with the latestlogs with a max size of 2 MB.
 public final class DiagnosticsLogger {
-    
-    // Struct holding any property that we want configurable by the user
-    public struct DiagnosticsConfiguration {
-        var maximumSize: ByteCountFormatter.Units.Bytes
-        var maximumNumberOfSession : Int?
-        public init(maximumSize:ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024,
-             maximumNumberOfSession: Int? = nil){
-            self.maximumSize = maximumSize
-            self.maximumNumberOfSession = maximumNumberOfSession
-        }
-    }
 
     static let standard = DiagnosticsLogger()
 
@@ -35,7 +34,6 @@ public final class DiagnosticsLogger {
 
     private let queue: DispatchQueue = DispatchQueue(label: "com.wetransfer.diagnostics.logger", qos: .utility, autoreleaseFrequency: .workItem, target: .global(qos: .utility))
 
-    
     private var logSize: ByteCountFormatter.Units.Bytes!
     private var maximumSize: ByteCountFormatter.Units.Bytes = 2 * 1024 * 1024 // 2 MB
     private let trimSize: ByteCountFormatter.Units.Bytes = 100 * 1024 // 100 KB
@@ -57,7 +55,7 @@ public final class DiagnosticsLogger {
     private var isSetup: Bool = false
     
     // Public Configuration
-    public var configuration : DiagnosticsConfiguration = DiagnosticsConfiguration()
+    public var configuration: DiagnosticsConfiguration = DiagnosticsConfiguration()
 
     /// Whether the logger is setup and ready to use.
     public static func isSetUp() -> Bool {

--- a/Sources/Extensions/UIDeviceExtensions.swift
+++ b/Sources/Extensions/UIDeviceExtensions.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-extension ByteCountFormatter.Units {
+public extension ByteCountFormatter.Units {
     typealias GigaBytes = String
     typealias Bytes = Int64
 }

--- a/Sources/Reporters/LogsReporter.swift
+++ b/Sources/Reporters/LogsReporter.swift
@@ -18,8 +18,12 @@ struct LogsReporter: DiagnosticsReporting {
             return "Parsing the log failed"
         }
 
-        let sessions = logs.addingHTMLEncoding().components(separatedBy: "\n\n---\n\n")
-        return sessions.reversed().joined(separator: "\n\n---\n\n")
+        var sessions = logs.addingHTMLEncoding().components(separatedBy: "\n\n---\n\n")
+        sessions = sessions.reversed()
+        if let maximumNumberOfSession = DiagnosticsLogger.standard.configuration.maximumNumberOfSession {
+            sessions = Array(sessions[0...maximumNumberOfSession])
+        }
+        return sessions.joined(separator: "\n\n---\n\n")
     }
 
     static func report() -> DiagnosticsChapter {


### PR DESCRIPTION
This is my PR allowing to make reports lighter. I deviated a bit from my original proposition.

### Changelog 
Added a way to configure logs `maximumSize ` as well as `maximumNumberOfSession ` through a  `DiagnosticsConfiguration` struct.

- `maximumSize ` property allow to change the actual size of the log file
- `maximumNumberOfSession ` allow to limit the number of sessions logged.  If you set that value to `nil`, no limit will apply.

You can use it likes :
```swift
let configuration = DiagnosticsConfiguration(
    maximumSize: 1 * 1024 * 1024, // 1MB
    maximumNumberOfSession: 10)
do {
    try DiagnosticsLogger.setup(configuration: configuration)
} catch {
    print(error.localizedDescription)
}
```

This is a non-breaking change, as using `DiagnosticsLogger.setup()` will use the default configuration, which is the same as the current one (2MB maximum size, no maximumNumberOfSession)
