### PR TITLE
native (aka non-catalyst) macOS support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The library allows to easily attach the Diagnostics Report as an attachment to t
 - [x] Possibility to filter out sensitive data using a `DiagnosticsReportFilter`
 - [x] A custom `DiagnosticsLogger` to add your own logs
 - [x] Flexible setup to add your own custom diagnostics
+- [x] Native cross-platform support, e.g. iOS, iPadOS and macOS
 
 ## Usage
 
@@ -99,6 +100,32 @@ extension ViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true)
     }
+}
+```
+
+On macOS you could send the report by using the `NSSharingService`:
+
+```swift
+import AppKit
+import Diagnostics
+
+func send(report: DiagnosticsReport) {
+    let service = NSSharingService(named: NSSharingService.Name.composeEmail)!
+    service.recipients = ["support@yourcompany.com"]
+    service.subject = "Diagnostics Report"
+            
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Diagnostics-Report.html")
+    
+    // remove previous report
+    try? FileManager.default.removeItem(at: url)
+
+    do {
+        try report.data.write(to: url)
+    } catch {
+        print("Failed with error: \(error)")
+    }
+
+    service.perform(withItems: [url])
 }
 ```
 

--- a/Sources/Device.swift
+++ b/Sources/Device.swift
@@ -1,5 +1,5 @@
 //
-//  UIDeviceExtensions.swift
+//  Device.swift
 //  Diagnostics
 //
 //  Created by Antoine van der Lee on 02/12/2019.
@@ -7,27 +7,41 @@
 //
 
 import Foundation
+#if os(macOS)
+import AppKit
+#else
 import UIKit
+#endif
 
-extension ByteCountFormatter.Units {
-    typealias GigaBytes = String
-    typealias Bytes = Int64
-}
-
-extension UIDevice {
-
-    var freeDiskSpace: ByteCountFormatter.Units.GigaBytes {
+enum Device {
+    static var systemName: String {
+        #if os(macOS)
+        return ProcessInfo().hostName
+        #else
+        return UIDevice.current.systemName
+        #endif
+    }
+    
+    static var systemVersion: String {
+        #if os(macOS)
+        return ProcessInfo().operatingSystemVersionString
+        #else
+        return UIDevice.current.systemVersion
+        #endif
+    }
+    
+    static var freeDiskSpace: ByteCountFormatter.Units.GigaBytes {
         return ByteCountFormatter.string(fromByteCount: freeDiskSpaceInBytes, countStyle: ByteCountFormatter.CountStyle.decimal)
     }
 
-    var totalDiskSpace: ByteCountFormatter.Units.GigaBytes {
+    static var totalDiskSpace: ByteCountFormatter.Units.GigaBytes {
         guard let systemAttributes = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory() as String),
             let space = (systemAttributes[FileAttributeKey.systemSize] as? NSNumber)?.int64Value else { return "UNKNOWN" }
 
         return ByteCountFormatter.string(fromByteCount: space, countStyle: ByteCountFormatter.CountStyle.decimal)
     }
 
-    var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
+    static var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
         if #available(iOS 11.0, *) {
             if let space = try? URL(fileURLWithPath: NSHomeDirectory() as String).resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForImportantUsageKey]).volumeAvailableCapacityForImportantUsage {
                 #if swift(>=5)

--- a/Sources/DiagnosticsLogger.swift
+++ b/Sources/DiagnosticsLogger.swift
@@ -7,7 +7,11 @@
 //
 
 import Foundation
+#if os(macOS)
+import AppKit
+#else
 import UIKit
+#endif
 
 /// A Diagnostics Logger to log messages to which will end up in the Diagnostics Report if using the default `LogsReporter`.
 /// Will keep a `.txt` log in the documents directory with the latestlogs with a max size of 2 MB.
@@ -137,7 +141,7 @@ extension DiagnosticsLogger {
         queue.async { [unowned self] in
             let date = self.formatter.string(from: Date())
             let appVersion = "\(Bundle.appVersion) (\(Bundle.appBuildNumber))"
-            let system = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+            let system = "\(Device.systemName) \(Device.systemVersion)"
             let locale = Locale.preferredLanguages[0]
 
             let message = date + "\n" + "System: \(system)\nLocale: \(locale)\nVersion: \(appVersion)\n\n"
@@ -185,7 +189,7 @@ extension DiagnosticsLogger {
         }
 
         // Make sure we have enough disk space left. This prevents a crash due to a lack of space.
-        guard UIDevice.current.freeDiskSpaceInBytes > minimumRequiredDiskSpace else { return }
+        guard Device.freeDiskSpaceInBytes > minimumRequiredDiskSpace else { return }
 
         fileHandle.seekToEndOfFile()
         fileHandle.write(data)

--- a/Sources/Extensions/BundleExtensions.swift
+++ b/Sources/Extensions/BundleExtensions.swift
@@ -1,5 +1,5 @@
 //
-//  UIApplicationExtensions.swift
+//  BundleExtensions.swift
 //  Diagnostics
 //
 //  Created by Antoine van der Lee on 02/12/2019.

--- a/Sources/Extensions/ByteCountFormatter.swift
+++ b/Sources/Extensions/ByteCountFormatter.swift
@@ -1,0 +1,14 @@
+//
+//  ByteCountFormatter.swift
+//  Diagnostics
+//
+//  Created by Antoine van der Lee on 02/12/2019.
+//  Copyright © 2019 WeTransfer. All rights reserved.
+//
+
+import Foundation
+
+extension ByteCountFormatter.Units {
+    typealias GigaBytes = String
+    typealias Bytes = Int64
+}

--- a/Sources/MFMailExtensions/MFMailComposeVCExtensions.swift
+++ b/Sources/MFMailExtensions/MFMailComposeVCExtensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
+#if canImport(MessageUI)
 import MessageUI
 
 public extension MFMailComposeViewController {
@@ -17,3 +18,4 @@ public extension MFMailComposeViewController {
     }
 
 }
+#endif

--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 /// Reports App and System specific metadata like OS and App version.
 public struct AppSystemMetadataReporter: DiagnosticsReporting {
@@ -60,7 +60,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
             hardware += " (\(hardwareName))"
         }
 
-        let system = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        let system = "\(Device.systemName) \(Device.systemVersion)"
 
         let metadata: [String: String] = [
             MetadataKey.appName.rawValue: Bundle.appName,
@@ -68,7 +68,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
             MetadataKey.appVersion.rawValue: "\(Bundle.appVersion) (\(Bundle.appBuildNumber))",
             MetadataKey.device.rawValue: hardware,
             MetadataKey.system.rawValue: system,
-            MetadataKey.freeSpace.rawValue: "\(UIDevice.current.freeDiskSpace) of \(UIDevice.current.totalDiskSpace)",
+            MetadataKey.freeSpace.rawValue: "\(Device.freeDiskSpace) of \(Device.totalDiskSpace)",
             MetadataKey.deviceLanguage.rawValue: Locale.current.languageCode ?? "Unknown",
             MetadataKey.appLanguage.rawValue: Locale.preferredLanguages[0]
             ]


### PR DESCRIPTION
Hi, first of all: thank you for this awesome framework! 🙂 

I want to use it with a non-catalyst app and added a [`enum Device`](https://github.com/JulianKahnert/Diagnostics/blob/master/Sources/Device.swift) that wraps the os specific information.
What do you think of this solution?