### PR TITLE
Merge release 1.8.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 1.8.0
+- Xcode-fix ([#76](https://github.com/WeTransfer/Diagnostics/pull/76)) via [@JulianKahnert](https://github.com/JulianKahnert)
+- Native (aka non-catalyst) macOS support added ([#75](https://github.com/WeTransfer/Diagnostics/pull/75)) via [@JulianKahnert](https://github.com/JulianKahnert)
+- Merge release 1.7.0 into master ([#70](https://github.com/WeTransfer/Diagnostics/pull/70)) via [@ghost](https://github.com/ghost)
+
 ### 1.7.0
 - Add crashes to our logs ([#63](https://github.com/WeTransfer/Diagnostics/issues/63)) via [@AvdLee](https://github.com/AvdLee)
 - Memory leaks in DiagnosticsLogger.handlePipeNotification ([#65](https://github.com/WeTransfer/Diagnostics/issues/65)) via [@AvdLee](https://github.com/AvdLee)

--- a/Diagnostics.podspec
+++ b/Diagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Diagnostics'
-  spec.version          = '1.7.0'
+  spec.version          = '1.8.0'
   spec.summary          = 'Create easy Diagnostics Reports and let user send them to your support team.'
   spec.description      = 'Diagnostics is a library written in Swift which makes it really easy to share Diagnostics Reports to your support team.'
 


### PR DESCRIPTION
Containing all the changes for our [**1.8.0 Release**](https://github.com/WeTransfer/Diagnostics/releases/tag/1.8.0).