### PR TITLE
Prevent setup twice, use file coordinator for increased performance

### DIFF
--- a/Diagnostics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Diagnostics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DiagnosticsTests/Reporters/LogsReporterTests.swift
+++ b/DiagnosticsTests/Reporters/LogsReporterTests.swift
@@ -11,14 +11,14 @@ import XCTest
 
 final class LogsReporterTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        try! DiagnosticsLogger.setup()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try DiagnosticsLogger.setup()
     }
 
-    override class func tearDown() {
-        try! DiagnosticsLogger.standard.deleteLogs()
-        super.tearDown()
+    override func tearDownWithError() throws {
+        try DiagnosticsLogger.standard.deleteLogs()
+        try super.tearDownWithError()
     }
     
     /// It should show logged messages.
@@ -26,7 +26,7 @@ final class LogsReporterTests: XCTestCase {
         let message = UUID().uuidString
         DiagnosticsLogger.log(message: message)
         let diagnostics = LogsReporter.report().diagnostics as! String
-        XCTAssertTrue(diagnostics.contains(message))
+        XCTAssertTrue(diagnostics.contains(message), "Diagnostics is \(diagnostics)")
     }
 
     /// It should show errors.
@@ -41,13 +41,13 @@ final class LogsReporterTests: XCTestCase {
     }
 
     /// It should reverse the order of sessions to have the most recent session on top.
-    func testReverseSessions() {
+    func testReverseSessions() throws {
         DiagnosticsLogger.log(message: "first")
         DiagnosticsLogger.standard.startNewSession()
         DiagnosticsLogger.log(message: "second")
         let diagnostics = LogsReporter.report().diagnostics as! String
-        let firstIndex = diagnostics.range(of: "first")!.lowerBound
-        let secondIndex = diagnostics.range(of: "second")!.lowerBound
+        let firstIndex = try XCTUnwrap(diagnostics.range(of: "first")?.lowerBound)
+        let secondIndex = try XCTUnwrap(diagnostics.range(of: "second")?.lowerBound)
         XCTAssertTrue(firstIndex > secondIndex)
     }
 


### PR DESCRIPTION
I've looked at other logging implementation, like [SwiftyBeaver](https://github.com/SwiftyBeaver/SwiftyBeaver/blob/fb468e5e3184f7e041ba46e5bfd0fc1670846eb6/Sources/FileDestination.swift#L114) and figured we could do a better job in terms of writing performance. Also, it seemed that certain logs weren't written when the app was in the background. The changes in this PR increase chances of logs ending up in the reports by closing the file handle right after writing.