### PR TITLE
Merge release 1.12.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 1.12.0
+- [CI] Update danger to latest fix tag ([#93](https://github.com/WeTransfer/Diagnostics/pull/93)) via [@AvdLee](https://github.com/AvdLee)
+- Merge release 1.11.0 into master ([#92](https://github.com/WeTransfer/Diagnostics/pull/92)) via [@wetransferplatform](https://github.com/wetransferplatform)
+
 ### 1.11.0
 - Fix macOS Support ([#91](https://github.com/WeTransfer/Diagnostics/pull/91)) via [@AvdLee](https://github.com/AvdLee)
 - Merge release 1.10.0 into master ([#90](https://github.com/WeTransfer/Diagnostics/pull/90)) via [@wetransferplatform](https://github.com/wetransferplatform)

--- a/Diagnostics.podspec
+++ b/Diagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'Diagnostics'
-  spec.version          = '1.11.0'
+  spec.version          = '1.12.0'
   spec.summary          = 'Create easy Diagnostics Reports and let user send them to your support team.'
   spec.description      = 'Diagnostics is a library written in Swift which makes it really easy to share Diagnostics Reports to your support team.'
 


### PR DESCRIPTION
Containing all the changes for our [**1.12.0 Release**](https://github.com/WeTransfer/Diagnostics/releases/tag/1.12.0).