### PR TITLE
Diagnostics 2.0

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Diagnostics.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Diagnostics.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Diagnostics_Diagnostics"
+               BuildableName = "Diagnostics_Diagnostics"
+               BlueprintName = "Diagnostics_Diagnostics"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Diagnostics"
+               BuildableName = "Diagnostics"
+               BlueprintName = "Diagnostics"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DiagnosticsTests"
+               BuildableName = "DiagnosticsTests"
+               BlueprintName = "DiagnosticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DiagnosticsTests"
+               BuildableName = "DiagnosticsTests"
+               BlueprintName = "DiagnosticsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Diagnostics_Diagnostics"
+            BuildableName = "Diagnostics_Diagnostics"
+            BlueprintName = "Diagnostics_Diagnostics"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DiagnosticsTests/DiagnosticsReporterTests.swift
+++ b/DiagnosticsTests/DiagnosticsReporterTests.swift
@@ -62,14 +62,6 @@ final class DiagnosticsReporterTests: XCTestCase {
         XCTAssertTrue(html.contains(DiagnosticsReporter.style()))
         XCTAssertTrue(html.contains("</head>"))
     }
-
-    /// It should minify CSS.
-    func testCSSMinify() {
-        let style = DiagnosticsReporter.style()
-        XCTAssertFalse(style.contains(where: { $0.isNewline }))
-        XCTAssertFalse(style.contains("  "), "It should not contain double spaces")
-    }
-
 }
 
 struct MockedReport: DiagnosticsReporting {

--- a/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
+++ b/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
@@ -30,7 +30,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         } catch {
             print("Failed to setup the Diagnostics Logger")
         }
-        
+
         DiagnosticsLogger.log(message: "Application started")
         DiagnosticsLogger.log(message: "Log <a href=\"https://www.wetransfer.com\">HTML</a>")
         DiagnosticsLogger.log(error: ExampleError.missingData)

--- a/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
+++ b/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
@@ -32,6 +32,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         DiagnosticsLogger.log(message: "Application started")
+        DiagnosticsLogger.log(message: "Log <a href=\"https://www.wetransfer.com\">HTML</a>")
         DiagnosticsLogger.log(error: ExampleError.missingData)
         DiagnosticsLogger.log(error: ExampleLocalizedError.missingLocalizedData)
         // Override point for customization after application launch.

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,12 @@ let package = Package(name: "Diagnostics",
                         ],
                       targets: [
                         // dev .target(name: "DangerDependencies", dependencies: [.product(name: "Danger", package: "danger-swift"), .product(name: "WeTransferPRLinter", package: "WeTransferPRLinter")], path: "Submodules/WeTransfer-iOS-CI/DangerFakeSources", sources: ["DangerFakeSource.swift"]),
-                        .target(name: "Diagnostics", path: "Sources", exclude: ["style.css"]),
+                        .target(
+                            name: "Diagnostics",
+                            path: "Sources",
+                            resources: [
+                                .process("style.css")
+                            ]),
                         .testTarget(name: "DiagnosticsTests", dependencies: ["Diagnostics"], path: "DiagnosticsTests")
                         ],
                       swiftLanguageVersions: [.v5])

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(name: "Diagnostics",
                             name: "Diagnostics",
                             path: "Sources",
                             resources: [
-                                .process("style.css")
+                                .process("style.css"),
+                                .process("functions.js")
                             ]),
                         .testTarget(name: "DiagnosticsTests", dependencies: ["Diagnostics"], path: "DiagnosticsTests")
                         ],

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -82,10 +82,9 @@ extension DiagnosticsReporter {
         var html = "<head>"
         html += "<title>\(Bundle.appName) - Diagnostics Report</title>"
         html += style()
+        html += scripts()
         html += "<meta charset=\"utf-8\">"
         html += "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
-        html += "<link rel=\"stylesheet\" href=\"/Users/avanderlee/Documents/GIT-Projects/WeTransfer/Diagnostics/Sources/style.css\">"
-        html += "<script src=\"/Users/avanderlee/Documents/GIT-Projects/WeTransfer/Diagnostics/Sources/functions.js\"></script>"
         html += "</head>"
         return html
     }
@@ -103,12 +102,17 @@ extension DiagnosticsReporter {
     }
 
     static func style() -> HTML {
-        /// To add Swift Package Manager support we're adding the CSS directly here. This is because we can't add resources to packages in SPM.
-        return ""
-//        guard let cssURL = Bundle.module.url(forResource: "style.css", withExtension: nil), let css = try? String(contentsOf: cssURL) else {
-//            return ""
-//        }
-//        return "<style>\(css)</style>"
+        guard let cssURL = Bundle.module.url(forResource: "style.css", withExtension: nil), let css = try? String(contentsOf: cssURL) else {
+            return ""
+        }
+        return "<style>\(css)</style>"
+    }
+
+    static func scripts() -> HTML {
+        guard let scriptsURL = Bundle.module.url(forResource: "functions.js", withExtension: nil), let scripts = try? String(contentsOf: scriptsURL) else {
+            return ""
+        }
+        return "<script type=\"text/javascript\">\(scripts)</script>"
     }
 
     static func menu(using chapters: [DiagnosticsChapter]) -> HTML {

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -84,6 +84,8 @@ extension DiagnosticsReporter {
         html += style()
         html += "<meta charset=\"utf-8\">"
         html += "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+        html += "<link rel=\"stylesheet\" href=\"/Users/avanderlee/Documents/GIT-Projects/WeTransfer/Diagnostics/Sources/style.css\">"
+        html += "<script src=\"/Users/avanderlee/Documents/GIT-Projects/WeTransfer/Diagnostics/Sources/functions.js\"></script>"
         html += "</head>"
         return html
     }
@@ -102,9 +104,11 @@ extension DiagnosticsReporter {
 
     static func style() -> HTML {
         /// To add Swift Package Manager support we're adding the CSS directly here. This is because we can't add resources to packages in SPM.
-        return """
-        <style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-size:1em;line-height:1.3em;margin:50px 50px 20px;color:#17181a}h1{margin:10px 0 20px;font-weight:400}h3{display:block;font-weight:400;font-size:20px;margin:0 0 10px}p{font-size:14px;margin:0 0 10px;display:block}p:last-child,ul:last-child{margin-bottom:0}pre{overflow:scroll}.container{display:flex;justify-content:space-between;flex-direction:row-reverse;margin:0 auto}.main-content{width:calc(100% - 190px)}.nav-container{width:180px}.nav-container nav{position:fixed;border-radius:4px}.nav-container nav ul{margin:0}.nav-container nav ul li{margin-bottom:5px;display:block}.nav-container nav ul li:last-child{margin-bottom:0}.nav-container nav ul li a{font-size:14px;color:#444;text-decoration:none}.nav-container nav ul li a:hover{color:#000;text-decoration:underline}.chapter{position:relative;margin-bottom:20px;padding-bottom:20px;border-bottom:1px solid #ccc}.chapter:last-child{border-bottom:0}.chapter .anchor{position:absolute;top:-20px}table th{text-align:left;padding:0 5px 0 0;font-weight:500}table td,table th{font-size:14px}footer{text-align:center;font-size:14px}footer a{color:#111}.footer-logo{width:20px;display:inline-block;vertical-align:middle}@media(max-width:768px){body{margin:20px}.container{margin:0}header h1{font-size:24px}.main-content{width:100%}.nav-container{display:none}table td,table th{display:block}table td{margin-bottom:5px}}@media (prefers-color-scheme:dark){body{background:#111;color:#f7f7f7}.chapter{border-bottom-color:rgba(255,255,255,.3)}.nav-container nav ul li a{color:rgba(255,255,255,.6)}.nav-container nav ul li a:hover{color:#fff}footer a{color:rgba(255,255,255,.85)}footer a:hover{color:#fff}.footer-logo path{fill:#f7f7f7}}</style>
-        """
+        return ""
+//        guard let cssURL = Bundle.module.url(forResource: "style.css", withExtension: nil), let css = try? String(contentsOf: cssURL) else {
+//            return ""
+//        }
+//        return "<style>\(css)</style>"
     }
 
     static func menu(using chapters: [DiagnosticsChapter]) -> HTML {
@@ -112,6 +116,11 @@ extension DiagnosticsReporter {
         chapters.forEach { chapter in
             html += "<li><a href=\"#\(chapter.title.anchor)\">\(chapter.title)</a></li>"
         }
+        html += "<li><button id=\"expand-sections\">Expand sessions</button></li>"
+        html += "<li><button id=\"collapse-sections\">Collapse sessions</button></li>"
+        html += "<li><input type=\"checkbox\" id=\"system-logs\" name=\"system-logs\" checked><label for=\"system-logs\">Show system logs</label></li>"
+        html += "<li><input type=\"checkbox\" id=\"error-logs\" name=\"error-logs\" checked><label for=\"error-logs\">Show error logs</label></li>"
+        html += "<li><input type=\"checkbox\" id=\"debug-logs\" name=\"debug-logs\" checked><label for=\"debug-logs\">Show debug logs</label></li>"
         html += "</ul></nav></aside>"
         return html
     }

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -54,7 +54,7 @@ public enum DiagnosticsReporter {
             }
             return chapter
         }
-        
+
         let html = generateHTML(using: reportChapters)
         let data = html.data(using: .utf8)!
         return DiagnosticsReport(filename: "Diagnostics-Report.html", data: data)

--- a/Sources/Extensions/DateFormatterExtensions.swift
+++ b/Sources/Extensions/DateFormatterExtensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension DateFormatter {
+    static let current: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.timeZone = TimeZone(identifier: "GMT")!
+        return formatter
+    }()
+}

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -1,0 +1,148 @@
+import Foundation
+import MetricKit
+
+protocol Loggable {
+    /// The message to log.
+    var message: String { get }
+
+    /// An optional CSS class to add to the log. If set, the log will be surrounded with a `<p>` as well.
+    var cssClass: String? { get }
+}
+
+extension Loggable {
+    var cssClass: String? { nil }
+
+    var logData: Data? {
+        if let cssClass = cssClass {
+            return "<p class=\"\(cssClass)\">\(message)</p>".data(using: .utf8)
+        } else {
+            return message.data(using: .utf8)
+        }
+    }
+}
+
+struct NewSession: Loggable {
+    let message: String
+
+    init() {
+        let date = DateFormatter.current.string(from: Date())
+        let appVersion = "\(Bundle.appVersion) (\(Bundle.appBuildNumber))"
+        let system = "\(Device.systemName) \(Device.systemVersion)"
+        let locale = Locale.preferredLanguages[0]
+
+        /// We start with `\n\n---\n\n` for backwards compatibility since it's
+        /// used for splitting the log into sections.
+        var message = "\n\n---\n\n<summary><div class=\"session-header\">"
+        message += "<p><span>Date: </span>\(date)</p>"
+        message += "<p><span>System: </span>\(system)</p>"
+        message += "<p><span>Locale: </span>\(locale)</p>"
+        message += "<p><span>Version: </span>\(appVersion)</p>"
+        message += "</div></summary>"
+        self.message = message
+    }
+}
+
+struct LogItem: Loggable {
+    enum LogType {
+        case debug(message: String)
+        case error(error: Error, description: String?)
+
+        var message: String {
+            switch self {
+            case .debug(let message):
+                return message
+            case .error(let error, let description):
+                var message = "\(error) | \(error.localizedDescription)"
+
+                if let description = description {
+                    message += " | \(description)"
+                }
+                return "ERROR: \(message)"
+            }
+        }
+
+        var cssClass: String {
+            switch self {
+            case .debug:
+                return "debug"
+            case .error:
+                return "error"
+            }
+        }
+    }
+
+    let message: String
+    let cssClass: String?
+
+    init(_ type: LogType, file: String, function: String, line: UInt) {
+        let date = DateFormatter.current.string(from: Date())
+        let file = file.split(separator: "/").last.map(String.init) ?? file
+        self.message = String(format: "%@ | %@:L%@ | %@", date, file, String(line), type.message)
+        self.cssClass = type.cssClass
+    }
+}
+
+struct SystemLog: Loggable {
+    let message: String
+    let cssClass: String? = "system"
+
+    init(line: String) {
+        let date = DateFormatter.current.string(from: Date())
+        message = "\(date) | SYSTEM: \(line)"
+    }
+}
+
+struct ExceptionLog: Loggable {
+    let message: String
+
+    init(_ exception: NSException, description: String) {
+        let message = """
+
+        ---
+
+        🚨 CRASH:
+        Description: \(description)
+        Exception name: \(exception.name.rawValue)
+        Reason: \(exception.reason ?? "nil")
+
+            \(Thread.callStackSymbols.joined(separator: "\n"))
+
+        ---
+
+        """
+
+        self.message = message
+    }
+}
+
+#if os(iOS)
+@available(iOS 14.0, *)
+extension MXDiagnosticPayload: Loggable {
+    var message: String {
+        """
+
+            ---
+            MXDIAGNOSTICS RECEIVED:
+            \(logDescription)
+            ---
+
+            """
+    }
+}
+
+@available(iOS 14.0, *)
+extension MXDiagnosticPayload {
+    var logDescription: String {
+        var logs: [String] = []
+        logs.append(contentsOf: crashDiagnostics?.compactMap { $0.logDescription } ?? [])
+        return logs.joined(separator: "\n")
+    }
+}
+
+@available(iOS 14.0, *)
+extension MXCrashDiagnostic {
+    var logDescription: String {
+        "💥 Reason: \(terminationReason ?? ""), Type: \(exceptionType?.stringValue ?? ""), Code: \(exceptionCode?.stringValue ?? ""), Signal: \(signal?.stringValue ?? ""), OS: \(metaData.osVersion), Build: \(metaData.applicationBuildVersion)"
+    }
+}
+#endif

--- a/Sources/MetricKit/MetricsMonitor.swift
+++ b/Sources/MetricKit/MetricsMonitor.swift
@@ -25,21 +25,7 @@ final class MetricsMonitor: NSObject {
 
     /// Creates a new log section with the current thread call stack symbols.
     private static func logExceptionUsingCallStackSymbols(_ exception: NSException, description: String) {
-        let message = """
-
-        ---
-
-        🚨 CRASH:
-        Description: \(description)
-        Exception name: \(exception.name.rawValue)
-        Reason: \(exception.reason ?? "nil")
-
-            \(Thread.callStackSymbols.joined(separator: "\n"))
-
-        ---
-
-        """
-        DiagnosticsLogger.standard.log(message)
+        DiagnosticsLogger.standard.log(ExceptionLog(exception, description: description))
     }
 }
 
@@ -57,31 +43,7 @@ extension MetricsMonitor: MXMetricManagerSubscriber {
             return
         }
 
-        let message = """
-
-            ---
-            MXDIAGNOSTICS RECEIVED:
-            \(payload.logDescription)
-            ---
-
-            """
-        DiagnosticsLogger.standard.log(message)
-    }
-}
-
-@available(iOS 14.0, *)
-extension MXDiagnosticPayload {
-    var logDescription: String {
-        var logs: [String] = []
-        logs.append(contentsOf: crashDiagnostics?.compactMap { $0.logDescription } ?? [])
-        return logs.joined(separator: "\n")
-    }
-}
-
-@available(iOS 14.0, *)
-extension MXCrashDiagnostic {
-    var logDescription: String {
-        "💥 Reason: \(terminationReason ?? ""), Type: \(exceptionType?.stringValue ?? ""), Code: \(exceptionCode?.stringValue ?? ""), Signal: \(signal?.stringValue ?? ""), OS: \(metaData.osVersion), Build: \(metaData.applicationBuildVersion)"
+        DiagnosticsLogger.standard.log(payload)
     }
 }
 #endif

--- a/Sources/Reporters/LogsReporter.swift
+++ b/Sources/Reporters/LogsReporter.swift
@@ -22,7 +22,7 @@ struct LogsReporter: DiagnosticsReporting {
         var diagnostics = ""
         sessions.forEach { session in
             guard !session.isEmpty else { return }
-            
+
             diagnostics += "<div class=\"collapsible-session\">"
             diagnostics += "<details>"
             if session.isOldStyleSession {

--- a/Sources/Reporters/LogsReporter.swift
+++ b/Sources/Reporters/LogsReporter.swift
@@ -11,15 +11,31 @@ import Foundation
 /// Creates a report chapter for all system and custom logs captured with the `DiagnosticsLogger`.
 struct LogsReporter: DiagnosticsReporting {
 
-    static var title: String = "Logs"
+    static var title: String = "Session Logs"
 
     static var diagnostics: String {
         guard let data = DiagnosticsLogger.standard.readLog(), let logs = String(data: data, encoding: .utf8) else {
             return "Parsing the log failed"
         }
 
-        let sessions = logs.addingHTMLEncoding().components(separatedBy: "\n\n---\n\n")
-        return sessions.reversed().joined(separator: "\n\n---\n\n")
+        let sessions = logs.components(separatedBy: "\n\n---\n\n").reversed()
+        var diagnostics = ""
+        sessions.forEach { session in
+            guard !session.isEmpty else { return }
+            
+            diagnostics += "<div class=\"collapsible-session\">"
+            diagnostics += "<details>"
+            if session.isOldStyleSession {
+                let title = session.split(whereSeparator: \.isNewline).first ?? "Unknown session title"
+                diagnostics += "<summary>\(title)</summary>"
+                diagnostics += "<pre>\(session.addingHTMLEncoding())</pre>"
+            } else {
+                diagnostics += session
+            }
+            diagnostics += "</details>"
+            diagnostics += "</div>"
+        }
+        return diagnostics
     }
 
     static func report() -> DiagnosticsChapter {
@@ -29,6 +45,12 @@ struct LogsReporter: DiagnosticsReporting {
 
 extension LogsReporter: HTMLFormatting {
     static func format(_ diagnostics: Diagnostics) -> HTML {
-        return "<pre>\(diagnostics)</pre>"
+        return "<div id=\"log-sessions\">\(diagnostics)</div>"
+    }
+}
+
+private extension String {
+    var isOldStyleSession: Bool {
+        !contains("class=\"session-header")
     }
 }

--- a/Sources/functions.js
+++ b/Sources/functions.js
@@ -1,0 +1,56 @@
+const expandElements = shouldExpand => {
+    let detailsElements = document.querySelectorAll("details");
+    
+    detailsElements = [...detailsElements];
+
+    if (shouldExpand) {
+        console.log("Expanding!");
+        detailsElements.map(item => item.setAttribute("open", shouldExpand));
+    } else {
+        console.log("Collapsing!");
+        detailsElements.map(item => item.removeAttribute("open"));
+    }
+};
+
+function showSystemLogs(shouldShow, className) {
+    document.querySelectorAll(className).forEach(function(el) {
+        if (shouldShow) {
+            el.style.display = 'block';
+        } else {
+            el.style.display = 'none';
+        }
+    });
+}
+
+window.onload = (function () {
+    document.getElementById("expand-sections").onclick = function() {
+        expandElements(true);
+    };
+    document.getElementById("collapse-sections").onclick = function() {
+        expandElements(false);
+    };
+
+    document.getElementById('system-logs').addEventListener('change', (event) => {
+      if (event.currentTarget.checked) {
+        showSystemLogs(true, '.system');
+      } else {
+        showSystemLogs(false, '.system');
+      }
+    });
+
+    document.getElementById('debug-logs').addEventListener('change', (event) => {
+      if (event.currentTarget.checked) {
+        showSystemLogs(true, '.debug');
+      } else {
+        showSystemLogs(false, '.debug');
+      }
+    });
+
+    document.getElementById('error-logs').addEventListener('change', (event) => {
+      if (event.currentTarget.checked) {
+        showSystemLogs(true, '.error');
+      } else {
+        showSystemLogs(false, '.error');
+      }
+    });
+});

--- a/Sources/style.css
+++ b/Sources/style.css
@@ -40,6 +40,10 @@ pre {
   overflow: scroll;
 }
 
+a {
+  color: #111;
+}
+
 .container {
   display: flex;
   justify-content: space-between;
@@ -109,13 +113,62 @@ table th, table td {
   font-size: 14px;
 }
 
+.collapsible-session {
+  margin: 15px 0px;
+}
+
+.error {
+  background-color: rgba(255, 0, 0, 0.4);
+}
+
+input[type=checkbox] {
+  margin: 10px 10px 10px 0px;
+}
+
+button {
+  margin: 10px 0px;
+}
+
+details {
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    padding: .5em .5em 0;
+    font-family: monospace;
+    white-space: pre;
+    font-size: 14px;
+    overflow: scroll;
+}
+
+summary {
+    margin: -.5em -.5em 0;
+    padding: .5em;
+}
+details > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+details > summary::marker {
+  display: none;
+}
+
+summary p {
+    font-size: 14px;
+    margin: 0px;
+}
+
+details[open] {
+    padding: .5em;
+}
+
+details[open] summary {
+    border-bottom: 1px solid #aaa;
+    margin-bottom: .5em;
+}
+
 footer {
   text-align: center;
   font-size: 14px;
-}
-
-footer a {
-  color: #111;
 }
 
 .footer-logo {
@@ -166,11 +219,11 @@ footer a {
     color: #fff;
   }
 
-  footer a {
+  a {
     color: rgba(255,255,255,0.85);
   }
 
-  footer a:hover {
+  a:hover {
     color: #fff;
   }
 


### PR DESCRIPTION
This is our first major improvement of the Diagnostics report we've been using for more than a year now at WeTransfer. Based on our experience, these changes are needed to make it easier to find out what's wrong with the user that reported in.

The main goal of these changes is to speed up the time from a bug report to a fix. 🚀 

- Added filter options to hide system, errors, and debug logs (Fixes #96, Fixes #82)
- Added buttons to collapse/expand all sessions (Fixes #101, Fixes #95)
- Added CSS for errors to show them with a red background to easily find errors in logs
- Proper support for logging HTML links by no longer using `<pre>` (Fixes #102)
- Fixed CSS for links (Fixes #100)
- Using SPM resources instead of inline CSS and Javascript, allowing us to maintain CSS and JS in individual files

Changes in action:

https://user-images.githubusercontent.com/4329185/139450523-f6600410-c1e9-4e5d-a604-1a8b28d97818.mov

