### PR TITLE
Catch obj-c exception, remove unneeded dispatch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,13 @@ let package = Package(name: "Diagnostics",
                       products: [
                         .library(name: "Diagnostics", type: .static, targets: ["Diagnostics"])
                         ],
+                      dependencies: [
+                        .package(url: "https://github.com/sindresorhus/ExceptionCatcher", from: "2.0.0")
+                      ],
                       targets: [
                         .target(
                             name: "Diagnostics",
+                            dependencies: ["ExceptionCatcher"],
                             path: "Sources",
                             resources: [
                                 .process("style.css"),


### PR DESCRIPTION
FileHandles can potentially throw exceptions that aren't catchable by Swift. I experienced this by detaching/attaching the debugger. I decided to add a small dependency to catch this and at least prevent apps from crashing. 

Another small improvement removes an unnecessary dispatch since we dispatch again within the following method. 