### PR TITLE
Use String instead of StaticString to be more inline with swift-log behaviour

### DIFF
--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -62,7 +62,7 @@ public final class DiagnosticsLogger {
     ///   - file: The file from which the log is send. Defaults to `#file`.
     ///   - function: The functino from which the log is send. Defaults to `#function`.
     ///   - line: The line from which the log is send. Defaults to `#line`.
-    public static func log(message: String, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+    public static func log(message: String, file: String = #file, function: String = #function, line: UInt = #line) {
         standard.log(LogItem(.debug(message: message), file: file, function: function, line: line))
     }
 
@@ -73,7 +73,7 @@ public final class DiagnosticsLogger {
     ///   - file: The file from which the log is send. Defaults to `#file`.
     ///   - function: The functino from which the log is send. Defaults to `#function`.
     ///   - line: The line from which the log is send. Defaults to `#line`.
-    public static func log(error: Error, description: String? = nil, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) {
+    public static func log(error: Error, description: String? = nil, file: String = #file, function: String = #function, line: UInt = #line) {
         standard.log(LogItem(.error(error: error, description: description), file: file, function: function, line: line))
     }
 }

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -101,7 +101,7 @@ struct LogItem: Loggable {
     let message: String
     let cssClass: LoggableCSSClass?
 
-    init(_ type: LogType, file: StaticString, function: StaticString, line: UInt) {
+    init(_ type: LogType, file: String, function: String, line: UInt) {
         let file = String(describing: file).split(separator: "/").last.map(String.init) ?? String(describing: file)
         prefix = "\(file):L\(line)"
         self.message = type.message


### PR DESCRIPTION
I am wrapping `DiagnosticsLogger` inside a `LogHandler` from [swift-log](https://github.com/apple/swift-log) package so that I can use swift-log as the main logger for my app. 

But currently, Diagnostics is using StaticString for #file, #line, #function in the `log` method

[swift-log](https://github.com/apple/swift-log/blob/3577a992d373d0e7f75d1fdc6e6e4570b60a1e1f/Sources/Logging/LogHandler.swift#L129) is using `String` instead of `StaticString` for #file, #line, #function 

I think, changing `StaticString` to `String` would make it more interoperable with swift-log and provides more flexibility to integrate with other libraries as well. 

