### PR TITLE
Fix HTML encoding

### DIFF
--- a/DiagnosticsTests/Reporters/LogsReporterTests.swift
+++ b/DiagnosticsTests/Reporters/LogsReporterTests.swift
@@ -23,20 +23,25 @@ final class LogsReporterTests: XCTestCase {
 
     /// It should show logged messages.
     func testMessagesLog() throws {
-        let message = UUID().uuidString
+        let identifier = UUID().uuidString
+        let message = "<b>\(identifier)</b>"
         DiagnosticsLogger.log(message: message)
         let diagnostics = LogsReporter().report().diagnostics as! String
-        XCTAssertTrue(diagnostics.contains(message), "Diagnostics is \(diagnostics)")
+        XCTAssertTrue(diagnostics.contains(identifier), "Diagnostics is \(diagnostics)")
         XCTAssertEqual(diagnostics.debugLogs.count, 1)
         let debugLog = try XCTUnwrap(diagnostics.debugLogs.first)
-        XCTAssertTrue(debugLog.contains("<span class=\"log-prefix\">LogsReporterTests.swift:L27</span>"), "Prefix should be added")
-        XCTAssertTrue(debugLog.contains("<span class=\"log-message\">\(message)</span>"), "Log message should be added")
+        XCTAssertTrue(debugLog.contains("<span class=\"log-prefix\">LogsReporterTests.swift:L28</span>"), "Prefix should be added")
+        XCTAssertTrue(debugLog.contains("<span class=\"log-message\">&lt;b&gt;\(identifier)&lt;/b&gt;</span>"), "Log message should be added to \(debugLog)")
     }
 
     /// It should show errors.
     func testErrorLog() throws {
-        enum Error: Swift.Error {
+        enum Error: LocalizedError {
             case testCase
+
+            var errorDescription: String? {
+                return "<b>example description</b>"
+            }
         }
 
         DiagnosticsLogger.log(error: Error.testCase)
@@ -44,7 +49,7 @@ final class LogsReporterTests: XCTestCase {
         XCTAssertTrue(diagnostics.contains("testCase"))
         XCTAssertEqual(diagnostics.errorLogs.count, 1)
         let errorLog = try XCTUnwrap(diagnostics.errorLogs.first)
-        XCTAssertTrue(errorLog.contains("<span class=\"log-message\">ERROR: testCase"))
+        XCTAssertTrue(errorLog.contains("<span class=\"log-message\">ERROR: testCase | &lt;b&gt;example description&lt;/b&gt"))
     }
 
     /// It should reverse the order of sessions to have the most recent session on top.

--- a/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
+++ b/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
@@ -32,7 +32,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         DiagnosticsLogger.log(message: "Application started")
-        DiagnosticsLogger.log(message: "Log <a href=\"https://www.wetransfer.com\">HTML</a>")
         DiagnosticsLogger.log(error: ExampleError.missingData)
         DiagnosticsLogger.log(error: ExampleLocalizedError.missingLocalizedData)
         DiagnosticsLogger.log(message: "A very long string: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque condimentum facilisis arcu, at fermentum diam fermentum in. Nullam lectus libero, tincidunt et risus vel, feugiat vulputate nunc. Nunc malesuada congue risus fringilla lacinia. Aliquam suscipit nulla nec faucibus mattis. Suspendisse quam nunc, interdum vel dapibus in, vulputate ac enim. Morbi placerat commodo leo, nec condimentum eros dictum sit amet. Vivamus maximus neque in dui rutrum, vel consectetur metus mollis. Nulla ultricies sodales viverra. Etiam ut velit consectetur, consectetur turpis eu, volutpat purus. Maecenas vitae consectetur tortor, at eleifend lacus. Nullam sed augue vel purus mollis sagittis at sed dui. Quisque faucibus fermentum lectus eget porttitor. Phasellus efficitur aliquet lobortis. Suspendisse at lectus imperdiet, sollicitudin arcu non, interdum diam. Sed ornare ante dolor. In pretium auctor sem, id vestibulum sem molestie in.")

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -75,14 +75,14 @@ struct LogItem: Loggable {
         var message: String {
             switch self {
             case .debug(let message):
-                return message
+                return message.addingHTMLEncoding()
             case .error(let error, let description):
                 var message = "\(error) | \(error.localizedDescription)"
 
                 if let description = description {
                     message += " | \(description)"
                 }
-                return "ERROR: \(message)"
+                return "ERROR: \(message)".addingHTMLEncoding()
             }
         }
 

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -82,6 +82,7 @@ struct LogItem: Loggable {
                 if let description = description {
                     message += " | \(description)"
                 }
+
                 return "ERROR: \(message)".addingHTMLEncoding()
             }
         }


### PR DESCRIPTION
We supported printing HTML in logs, but that often resulted in our Diagnostics reports breaking since nothing was stopping users from printing `<link ...css>` as well.

I tried writing a solution to enable certain tags like `<a>` for example, but I couldn't find a solution without adding an extra dependency to the project. I decided it's not worth adding that for now and instead ensured all HTML is encoded.

Fixes #120 