### PR TITLE
Fix infinite loop happening on iOS 16 devices

### DIFF
--- a/Sources/Device.swift
+++ b/Sources/Device.swift
@@ -31,36 +31,28 @@ enum Device {
     }
 
     static var freeDiskSpace: ByteCountFormatter.Units.GigaBytes {
-        return ByteCountFormatter.string(fromByteCount: freeDiskSpaceInBytes, countStyle: ByteCountFormatter.CountStyle.decimal)
+        ByteCountFormatter.string(fromByteCount: freeDiskSpaceInBytes, countStyle: ByteCountFormatter.CountStyle.decimal)
     }
 
     static var totalDiskSpace: ByteCountFormatter.Units.GigaBytes {
-        guard let systemAttributes = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory() as String),
-            let space = (systemAttributes[FileAttributeKey.systemSize] as? NSNumber)?.int64Value else { return "UNKNOWN" }
+        ByteCountFormatter.string(fromByteCount: totalDiskSpaceInBytes, countStyle: ByteCountFormatter.CountStyle.decimal)
+    }
 
-        return ByteCountFormatter.string(fromByteCount: space, countStyle: ByteCountFormatter.CountStyle.decimal)
+    static var totalDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
+        guard let space = try? URL(fileURLWithPath: NSHomeDirectory() as String)
+            .resourceValues(forKeys: [URLResourceKey.volumeTotalCapacityKey])
+            .volumeTotalCapacity else {
+            return 0
+        }
+        return Int64(space)
     }
 
     static var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
-        if #available(iOS 11.0, *) {
-            if let space = try? URL(fileURLWithPath: NSHomeDirectory() as String)
-                .resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForImportantUsageKey])
-                .volumeAvailableCapacityForImportantUsage {
-                #if swift(>=5)
-                    return space
-                #else
-                    return space ?? 0
-                #endif
-            } else {
-                return 0
-            }
-        } else {
-            if let systemAttributes = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory() as String),
-            let freeSpace = (systemAttributes[FileAttributeKey.systemFreeSize] as? NSNumber)?.int64Value {
-                return freeSpace
-            } else {
-                return 0
-            }
+        guard let space = try? URL(fileURLWithPath: NSHomeDirectory() as String)
+            .resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForOpportunisticUsageKey])
+            .volumeAvailableCapacityForOpportunisticUsage else {
+            return 0
         }
+        return space
     }
 }


### PR DESCRIPTION
Running Diagnostics on iOS 16 resulted in a deadlock since checking for system available space results in system logs being triggered on iOS 16 and up. Since we capture system logs, we would try to log them again, check for system space, triggering another system log. Since we capture system logs, we would try to log them again, check for system space, triggering another system log. Since we capture system logs, we would try to log them again, check for system space, triggering another system log. Since we capture system logs, we would try to log them again, check for system space, triggering another system log.

I added a threshold to ensure that we only check for free disk space periodically, solving this issue.

Furthermore:
- [x] Using the correct methods to determine system total size. Compared it to my test device and found a match
- [x] Using `optimistic` free size instead of `importantUsage` since our logs are not as crucial as other user content. Secondly, I rather am on the safe side, and `optimistic` returns a lower number
- [x] Removed unnecessary checks for the Swift version and iOS 11