### PR TITLE
Fix macCatalyst support

### DIFF
--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -74,7 +74,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
             MetadataKey.deviceLanguage.rawValue: Locale.current.languageCode ?? "Unknown",
             MetadataKey.appLanguage.rawValue: Locale.preferredLanguages[0]
         ]
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
             let cellularData = CTCellularData()
             metadata[MetadataKey.cellularAllowed.rawValue] = "\(cellularData.restrictedState)"
         #endif
@@ -86,7 +86,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
     }
 }
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 extension CTCellularDataRestrictedState: CustomStringConvertible {
      public var description: String {
         switch self {

--- a/Sources/Reporters/SmartInsightsReporter.swift
+++ b/Sources/Reporters/SmartInsightsReporter.swift
@@ -45,7 +45,7 @@ public struct SmartInsightsReporter: DiagnosticsReporting {
             DeviceStorageInsight(),
             UpdateAvailableInsight()
         ]
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
             defaultInsights.append(CellularAllowedInsight())
         #endif
         

--- a/Sources/SmartInsights/CellularAllowedInsight.swift
+++ b/Sources/SmartInsights/CellularAllowedInsight.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreTelephony
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 /// Shows an insight on whether the user has enabled cellular data system-wide for this app.
 struct CellularAllowedInsight: SmartInsightProviding {
 


### PR DESCRIPTION
Because [`CTCellularData`](https://developer.apple.com/documentation/coretelephony/ctcellulardata) is unavailable for macCatalyst, I added `!targetEnvironment(macCatalyst)` to the already existing `#if os(iOS)` checks.