### PR TITLE
Let developer set App Store region for UpdateAvailableInsight

### DIFF
--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -30,7 +30,7 @@ public enum DiagnosticsReporter {
             case .appSystemMetadata:
                 return AppSystemMetadataReporter()
             case .smartInsights:
-                return SmartInsightsReporter(itunesRegion: "us")
+                return SmartInsightsReporter()
             case .logs:
                 return LogsReporter()
             case .userDefaults:
@@ -54,7 +54,6 @@ public enum DiagnosticsReporter {
     ///   - smartInsightsProvider: Provide any smart insights for the given `DiagnosticsChapter`.
     public static func create(
         filename: String = "Diagnostics-Report.html",
-        itunesRegion: String = "us",
         using reporters: [DiagnosticsReporting] = DefaultReporter.allReporters,
         filters: [DiagnosticsReportFilter.Type]? = nil,
         smartInsightsProvider: SmartInsightsProviding? = nil
@@ -81,7 +80,7 @@ public enum DiagnosticsReporter {
             }
 
         if let smartInsightsChapterIndex = reporters.firstIndex(where: { $0 is SmartInsightsReporter }) {
-            var smartInsightsReporter = SmartInsightsReporter(itunesRegion: itunesRegion)
+            var smartInsightsReporter = SmartInsightsReporter()
             smartInsightsReporter.insights.append(contentsOf: smartInsights)
             let smartInsightsChapter = smartInsightsReporter.report()
             reportChapters.insert(smartInsightsChapter, at: smartInsightsChapterIndex)

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -30,7 +30,7 @@ public enum DiagnosticsReporter {
             case .appSystemMetadata:
                 return AppSystemMetadataReporter()
             case .smartInsights:
-                return SmartInsightsReporter()
+                return SmartInsightsReporter(itunesRegion: "us")
             case .logs:
                 return LogsReporter()
             case .userDefaults:
@@ -53,6 +53,8 @@ public enum DiagnosticsReporter {
     ///   - filters: The filters to use for the generated diagnostics. Should conform to the `DiagnosticsReportFilter` protocol.
     ///   - smartInsightsProvider: Provide any smart insights for the given `DiagnosticsChapter`.
     public static func create(
+        filename: String = "Diagnostics-Report.html",
+        itunesRegion: String = "us",
         using reporters: [DiagnosticsReporting] = DefaultReporter.allReporters,
         filters: [DiagnosticsReportFilter.Type]? = nil,
         smartInsightsProvider: SmartInsightsProviding? = nil
@@ -79,7 +81,7 @@ public enum DiagnosticsReporter {
             }
 
         if let smartInsightsChapterIndex = reporters.firstIndex(where: { $0 is SmartInsightsReporter }) {
-            var smartInsightsReporter = SmartInsightsReporter()
+            var smartInsightsReporter = SmartInsightsReporter(itunesRegion: itunesRegion)
             smartInsightsReporter.insights.append(contentsOf: smartInsights)
             let smartInsightsChapter = smartInsightsReporter.report()
             reportChapters.insert(smartInsightsChapter, at: smartInsightsChapterIndex)
@@ -87,7 +89,7 @@ public enum DiagnosticsReporter {
 
         let html = generateHTML(using: reportChapters)
         let data = html.data(using: .utf8)!
-        return DiagnosticsReport(filename: "Diagnostics-Report.html", data: data)
+        return DiagnosticsReport(filename: filename, data: data)
     }
 }
 

--- a/Sources/Reporters/SmartInsightsReporter.swift
+++ b/Sources/Reporters/SmartInsightsReporter.swift
@@ -40,10 +40,10 @@ public struct SmartInsightsReporter: DiagnosticsReporting {
     let title: String = "Smart Insights"
     var insights: [SmartInsightProviding]
 
-    init() {
+    init(itunesRegion: String = "us") {
         var defaultInsights: [SmartInsightProviding?] = [
             DeviceStorageInsight(),
-            UpdateAvailableInsight()
+            UpdateAvailableInsight(itunesRegion: itunesRegion)
         ]
         #if os(iOS) && !targetEnvironment(macCatalyst)
             defaultInsights.append(CellularAllowedInsight())

--- a/Sources/Reporters/SmartInsightsReporter.swift
+++ b/Sources/Reporters/SmartInsightsReporter.swift
@@ -40,10 +40,10 @@ public struct SmartInsightsReporter: DiagnosticsReporting {
     let title: String = "Smart Insights"
     var insights: [SmartInsightProviding]
 
-    init(itunesRegion: String = "us") {
+    init() {
         var defaultInsights: [SmartInsightProviding?] = [
             DeviceStorageInsight(),
-            UpdateAvailableInsight(itunesRegion: itunesRegion)
+            UpdateAvailableInsight()
         ]
         #if os(iOS) && !targetEnvironment(macCatalyst)
             defaultInsights.append(CellularAllowedInsight())

--- a/Sources/SmartInsights/UpdateAvailableInsight.swift
+++ b/Sources/SmartInsights/UpdateAvailableInsight.swift
@@ -28,7 +28,7 @@ struct UpdateAvailableInsight: SmartInsightProviding {
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         currentVersion: String = Bundle.appVersion,
         appMetadataPublisher: AnyPublisher<AppMetadataResults, Error>? = nil,
-        itunesRegion: String = "us"
+        itunesRegion: String = Locale.current.regionCode ?? "us"
     ) {
         guard let bundleIdentifier = bundleIdentifier else { return nil }
         let url = URL(string: "https://itunes.apple.com/\(itunesRegion)/lookup?bundleId=\(bundleIdentifier)")!

--- a/Sources/SmartInsights/UpdateAvailableInsight.swift
+++ b/Sources/SmartInsights/UpdateAvailableInsight.swift
@@ -27,10 +27,11 @@ struct UpdateAvailableInsight: SmartInsightProviding {
     init?(
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         currentVersion: String = Bundle.appVersion,
-        appMetadataPublisher: AnyPublisher<AppMetadataResults, Error>? = nil
+        appMetadataPublisher: AnyPublisher<AppMetadataResults, Error>? = nil,
+        itunesRegion: String = "us"
     ) {
         guard let bundleIdentifier = bundleIdentifier else { return nil }
-        let url = URL(string: "https://itunes.apple.com/br/lookup?bundleId=\(bundleIdentifier)")!
+        let url = URL(string: "https://itunes.apple.com/\(itunesRegion)/lookup?bundleId=\(bundleIdentifier)")!
 
         let group = DispatchGroup()
         group.enter()


### PR DESCRIPTION
Hi,

just started using this library in one of my apps and noticed the report doesn't includes the update available smart insights because my app is only available in Spain and it tries to retrieve metadata from Brazilian App Store.
In this PR I include an optional parameter to set the iTunes region in the create report method. Also including the option to set custom report filename.

Congratulations for this great package.