### PR TITLE
Set minimum iOS support to iOS 11

### DIFF
--- a/DiagnosticsTests/Extensions/MFMailComposeViewControllerTests.swift
+++ b/DiagnosticsTests/Extensions/MFMailComposeViewControllerTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import Diagnostics
+#if canImport(MessageUI)
 import MessageUI
 
 final class MFMailComposeViewControllerTests: XCTestCase {
@@ -49,3 +50,4 @@ private final class MockedMFMailComposeViewController: MFMailComposeViewControll
         self.filename = filename
     }
 }
+#endif

--- a/DiagnosticsTests/Reporters/SmartInsights/UpdateAvailableInsightTests.swift
+++ b/DiagnosticsTests/Reporters/SmartInsights/UpdateAvailableInsightTests.swift
@@ -20,38 +20,52 @@ final class UpdateAvailableInsightTests: XCTestCase {
     }
 
     func testReturningNilIfNoAppMetadataAvailable() {
-        let publisher: AnyPublisher<AppMetadataResults, Error> = Fail(error: exampleError).eraseToAnyPublisher()
-        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, appMetadataPublisher: publisher)
+        let expectation = expectation(description: #function)
+        func appMetadataCompletion() -> Result<AppMetadataResults, Error> {
+            expectation.fulfill()
+            return Result.failure(exampleError)
+        }
+        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, appMetadataCompletion: appMetadataCompletion)
         XCTAssertNil(insight)
+        waitForExpectations(timeout: 1)
     }
 
     func testUserIsOnTheSameVersion() {
+        let expectation = expectation(description: #function)
         let appMetadata = AppMetadataResults(results: [.init(version: "1.0.0")])
-        let publisher: AnyPublisher<AppMetadataResults, Error> = Just(appMetadata)
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
+        func appMetadataCompletion() -> Result<AppMetadataResults, Error> {
+            expectation.fulfill()
+            return Result.success(appMetadata)
+        }
 
-        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "1.0.0", appMetadataPublisher: publisher)
+        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "1.0.0", appMetadataCompletion: appMetadataCompletion)
         XCTAssertEqual(insight?.result, .success(message: "The user is using the latest app version 1.0.0"))
+        waitForExpectations(timeout: 1)
     }
 
     func testUserIsOnANewerVersion() {
+        let expectation = expectation(description: #function)
         let appMetadata = AppMetadataResults(results: [.init(version: "1.0.0")])
-        let publisher: AnyPublisher<AppMetadataResults, Error> = Just(appMetadata)
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
+        func appMetadataCompletion() -> Result<AppMetadataResults, Error> {
+            expectation.fulfill()
+            return Result.success(appMetadata)
+        }
 
-        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "2.0.0", appMetadataPublisher: publisher)
+        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "2.0.0", appMetadataCompletion: appMetadataCompletion)
         XCTAssertEqual(insight?.result, .success(message: "The user is using a newer version 2.0.0"))
+        waitForExpectations(timeout: 1)
     }
 
     func testUserIsOnAnOlderVersion() {
+        let expectation = expectation(description: #function)
         let appMetadata = AppMetadataResults(results: [.init(version: "2.0.0")])
-        let publisher: AnyPublisher<AppMetadataResults, Error> = Just(appMetadata)
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
+        func appMetadataCompletion() -> Result<AppMetadataResults, Error> {
+            expectation.fulfill()
+            return Result.success(appMetadata)
+        }
 
-        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "1.0.0", appMetadataPublisher: publisher)
+        let insight = UpdateAvailableInsight(bundleIdentifier: sampleBundleIdentifier, currentVersion: "1.0.0", appMetadataCompletion: appMetadataCompletion)
         XCTAssertEqual(insight?.result, .warn(message: "The user could update to 2.0.0"))
+        waitForExpectations(timeout: 1)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(name: "Diagnostics",
                       platforms: [
                         .macOS(.v10_15),
-                        .iOS(.v13),
+                        .iOS(.v11),
                         .tvOS(.v12),
                         .watchOS(.v6)],
                       products: [

--- a/Sources/Reporters/SmartInsightsReporter.swift
+++ b/Sources/Reporters/SmartInsightsReporter.swift
@@ -48,7 +48,7 @@ public struct SmartInsightsReporter: DiagnosticsReporting {
         #if os(iOS) && !targetEnvironment(macCatalyst)
             defaultInsights.append(CellularAllowedInsight())
         #endif
-        
+
         insights = defaultInsights.compactMap { $0 }
     }
 


### PR DESCRIPTION
We would like to integrate this great package into our app but our app is still supporting iOS 11+.

It looks like that the main functionality of the package is available for iOS 11, only a default SmartInsight requires iOS 13+ due to Combine

I have added some availability checks for that SmartInsight and set the minimum iOS platform version to 11.