### PR TITLE
Fix: unblock building for VisionOS Simulator

### DIFF
--- a/Sources/DiagnosticsReport.swift
+++ b/Sources/DiagnosticsReport.swift
@@ -40,7 +40,7 @@ public extension DiagnosticsReport {
             try? FileManager.default.createDirectory(atPath: folderPath, withIntermediateDirectories: true, attributes: nil)
             let filePath = folderPath + filename
             save(to: filePath)
-        #else
+        #elseif os(OSX)
             let folderPath = "/\(userPath)/Desktop/"
             saveUsingPanel(initialDirectoryPath: folderPath, filename: filename)
         #endif

--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -6,7 +6,11 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
-import CoreTelephony
+
+#if canImport(CoreTelephony)
+    import CoreTelephony
+#endif
+
 import Foundation
 
 /// Reports App and System specific metadata like OS and App version.

--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
-
 #if canImport(CoreTelephony)
     import CoreTelephony
 #endif

--- a/Sources/SmartInsights/CellularAllowedInsight.swift
+++ b/Sources/SmartInsights/CellularAllowedInsight.swift
@@ -1,11 +1,13 @@
 //
 //  CellularAllowedInsight.swift
-//  
+//
 //
 //  Created by Antoine van der Lee on 27/07/2022.
 //
 
-import CoreTelephony
+#if canImport(CoreTelephony)
+    import CoreTelephony
+#endif
 import Foundation
 
 #if os(iOS) && !targetEnvironment(macCatalyst)


### PR DESCRIPTION
When building for the VisionOS simulator, Xcode throws errors on availability of `CoreTelephony`. This PR conditionally imports `CoreTelephony`. 

<img width="937" alt="Screenshot 2023-09-01 at 16 26 34" src="https://github.com/WeTransfer/Diagnostics/assets/366337/c2e5d87a-ffc6-4c30-a585-9f8afa59f2e6">
