### PR TITLE
Allow an alternative log location to Documents folder to be specified

### DIFF
--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -71,11 +71,12 @@ public final class DiagnosticsLogger {
 
     /// Sets up the logger to be ready for usage. This needs to be called before any log messages are reported.
     /// This method also starts a new session.
-    public static func setup() throws {
+    public static func setup(customLogFolder: URL? = nil) throws {
         guard !isSetUp() || standard.isRunningTests else {
             return
         }
-        try standard.setup()
+
+        try standard.setup(customLogFolder: customLogFolder)
     }
 
     /// Logs the given message for the diagnostics report.
@@ -109,10 +110,14 @@ public final class DiagnosticsLogger {
 // MARK: - Setup
 extension DiagnosticsLogger {
 
-    private func setup() throws {
+    private func setup(customLogFolder: URL? = nil) throws {
+
+        let logFolder: URL = customLogFolder ?? FileManager.default.documentsDirectory
+        logFileLocation = logFolder.appendingPathComponent("diagnostics_log.txt")
+
         if !FileManager.default.fileExists(atPath: logFileLocation.path) {
             try FileManager.default
-                .createDirectory(atPath: FileManager.default.documentsDirectory.path, withIntermediateDirectories: true, attributes: nil)
+                .createDirectory(atPath: logFolder.path, withIntermediateDirectories: true, attributes: nil)
             guard FileManager.default.createFile(atPath: logFileLocation.path, contents: nil, attributes: nil) else {
                 assertionFailure("Unable to create the log file")
                 return


### PR DESCRIPTION
On MacOS, for unsandboxed apps, the log file appears in the `~/Documents` folder.

![CleanShot 2023-12-18 at 15 03 03@2x](https://github.com/WeTransfer/Diagnostics/assets/1131967/a19f910e-0a39-4326-9cac-c9f56cab3d84)

It would be good to be able to specify an alternative location for the logs to be saved into.

Downside of this approach: two separate definitions setting  `logFileLocation` to `"diagnostics_log.txt"`, would welcome alternative suggestion.