### PR TITLE
[TMOB 5114] Log failures happening during log reading

### DIFF
--- a/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
+++ b/Example/Diagnostics-Example/Supporting Files/AppDelegate.swift
@@ -5,7 +5,6 @@
 //  Created by Antoine van der Lee on 02/12/2019.
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
-//  swiftlint:disable line_length
 import Diagnostics
 import UIKit
 
@@ -24,7 +23,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         do {
             try DiagnosticsLogger.setup()
         } catch {
@@ -34,6 +36,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         DiagnosticsLogger.log(message: "Application started")
         DiagnosticsLogger.log(error: ExampleError.missingData)
         DiagnosticsLogger.log(error: ExampleLocalizedError.missingLocalizedData)
+        //  swiftlint:disable:next line_length
         DiagnosticsLogger.log(message: "A very long string: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque condimentum facilisis arcu, at fermentum diam fermentum in. Nullam lectus libero, tincidunt et risus vel, feugiat vulputate nunc. Nunc malesuada congue risus fringilla lacinia. Aliquam suscipit nulla nec faucibus mattis. Suspendisse quam nunc, interdum vel dapibus in, vulputate ac enim. Morbi placerat commodo leo, nec condimentum eros dictum sit amet. Vivamus maximus neque in dui rutrum, vel consectetur metus mollis. Nulla ultricies sodales viverra. Etiam ut velit consectetur, consectetur turpis eu, volutpat purus. Maecenas vitae consectetur tortor, at eleifend lacus. Nullam sed augue vel purus mollis sagittis at sed dui. Quisque faucibus fermentum lectus eget porttitor. Phasellus efficitur aliquet lobortis. Suspendisse at lectus imperdiet, sollicitudin arcu non, interdum diam. Sed ornare ante dolor. In pretium auctor sem, id vestibulum sem molestie in.")
         // Override point for customization after application launch.
         return true
@@ -41,7 +44,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -5,7 +5,6 @@
 //  Created by Antoine van der Lee on 02/12/2019.
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
-//  swiftlint:disable line_length
 
 import Foundation
 
@@ -120,6 +119,7 @@ extension DiagnosticsReporter {
         return html
     }
 
+    //  swiftlint:disable line_length
     private static func footer() -> HTML {
         return """
         <footer>
@@ -131,6 +131,7 @@ extension DiagnosticsReporter {
         </footer>
         """
     }
+    //  swiftlint:enable line_length
 
     static func style() -> HTML {
         guard let cssURL = Bundle.module.url(forResource: "style.css", withExtension: nil), let css = try? String(contentsOf: cssURL) else {
@@ -140,12 +141,15 @@ extension DiagnosticsReporter {
     }
 
     static func scripts() -> HTML {
-        guard let scriptsURL = Bundle.module.url(forResource: "functions.js", withExtension: nil), let scripts = try? String(contentsOf: scriptsURL) else {
+        guard
+            let scriptsURL = Bundle.module.url(forResource: "functions.js", withExtension: nil),
+            let scripts = try? String(contentsOf: scriptsURL) else {
             return ""
         }
         return "<script type=\"text/javascript\">\(scripts)</script>"
     }
 
+    //  swiftlint:disable line_length
     static func menu(using chapters: [DiagnosticsChapter]) -> HTML {
         var html = "<aside class=\"nav-container\"><nav><ul>"
         chapters.forEach { chapter in
@@ -159,6 +163,7 @@ extension DiagnosticsReporter {
         html += "</ul></nav></aside>"
         return html
     }
+    //  swiftlint:enable line_length
 
     static func mainContent(using chapters: [DiagnosticsChapter]) -> HTML {
         var html = "<div class=\"main-content\">"

--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -138,19 +138,31 @@ extension DiagnosticsLogger {
     }
 
     /// Reads the log and converts it to a `Data` object.
-    func readLog() -> Data? {
+    func readLog() throws -> Data? {
         guard isSetup else {
             assertionFailure("Trying to read the log while not set up")
             return nil
         }
 
-        return queue.sync {
+        return try queue.sync {
             let coordinator = NSFileCoordinator(filePresenter: nil)
-            var error: NSError?
+            var coordinateError: NSError?
+            var dataError: Error?
             var logData: Data?
-            coordinator.coordinate(readingItemAt: logFileLocation, error: &error) { url in
-                logData = try? Data(contentsOf: url)
+            coordinator.coordinate(readingItemAt: logFileLocation, error: &coordinateError) { url in
+                do {
+                    logData = try Data(contentsOf: url)
+                } catch {
+                    dataError = error
+                }
             }
+
+            if let coordinateError {
+                throw coordinateError
+            } else if let dataError {
+                throw dataError
+            }
+
             return logData
         }
     }

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -200,7 +200,7 @@ extension MXCallStackTree {
 extension String.StringInterpolation {
     // swiftlint:disable:next cyclomatic_complexity
     mutating func appendInterpolation(exceptionType: Int32?) {
-        guard let exceptionType = exceptionType else {
+        guard let exceptionType else {
             appendLiteral("")
             return
         }
@@ -244,7 +244,7 @@ extension String.StringInterpolation {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     mutating func appendInterpolation(signal: Int32?) {
-        guard let signal = signal else {
+        guard let signal else {
             appendLiteral("")
             return
         }

--- a/Sources/Reporters/GeneralInfoReporter.swift
+++ b/Sources/Reporters/GeneralInfoReporter.swift
@@ -35,3 +35,4 @@ open class GeneralInfoReporter: DiagnosticsReporting {
         return DiagnosticsChapter(title: title, diagnostics: description, shouldShowTitle: false)
     }
 }
+//  swiftlint:enable line_length

--- a/Sources/Reporters/LogsReporter.swift
+++ b/Sources/Reporters/LogsReporter.swift
@@ -14,28 +14,32 @@ struct LogsReporter: DiagnosticsReporting {
     let title: String = "Session Logs"
 
     var diagnostics: String {
-        guard let data = DiagnosticsLogger.standard.readLog(), let logs = String(data: data, encoding: .utf8) else {
-            return "Parsing the log failed"
-        }
-
-        let sessions = logs.components(separatedBy: "\n\n---\n\n").reversed()
-        var diagnostics = ""
-        sessions.forEach { session in
-            guard !session.isEmpty else { return }
-
-            diagnostics += "<div class=\"collapsible-session\">"
-            diagnostics += "<details>"
-            if session.isOldStyleSession {
-                let title = session.split(whereSeparator: \.isNewline).first ?? "Unknown session title"
-                diagnostics += "<summary>\(title)</summary>"
-                diagnostics += "<pre>\(session.addingHTMLEncoding())</pre>"
-            } else {
-                diagnostics += session
+        do {
+            guard let data = try DiagnosticsLogger.standard.readLog(), let logs = String(data: data, encoding: .utf8) else {
+                return "Parsing the log failed (Unknown error)"
             }
-            diagnostics += "</details>"
-            diagnostics += "</div>"
+
+            let sessions = logs.components(separatedBy: "\n\n---\n\n").reversed()
+            var diagnostics = ""
+            sessions.forEach { session in
+                guard !session.isEmpty else { return }
+
+                diagnostics += "<div class=\"collapsible-session\">"
+                diagnostics += "<details>"
+                if session.isOldStyleSession {
+                    let title = session.split(whereSeparator: \.isNewline).first ?? "Unknown session title"
+                    diagnostics += "<summary>\(title)</summary>"
+                    diagnostics += "<pre>\(session.addingHTMLEncoding())</pre>"
+                } else {
+                    diagnostics += session
+                }
+                diagnostics += "</details>"
+                diagnostics += "</div>"
+            }
+            return diagnostics
+        } catch {
+            return "Parsing the log failed (\(error.localizedDescription))"
         }
-        return diagnostics
     }
 
     func report() -> DiagnosticsChapter {


### PR DESCRIPTION
There have been instances where logs wouldn't be readable, failing with:

```
Parsing the log failed
```

Since we did not log any related failures, it's hard to conclude what went wrong. This PR enables logging thrown errors so we can better debug this in the future.

_Note: often a regeneration/retry solved the issue for users._