### PR TITLE
[TMOB 5115] Trim using lines instead of bytes

### DIFF
--- a/DiagnosticsTests/Reporters/LogsReporterTests.swift
+++ b/DiagnosticsTests/Reporters/LogsReporterTests.swift
@@ -62,5 +62,4 @@ final class LogsReporterTests: XCTestCase {
         let secondIndex = try XCTUnwrap(diagnostics.range(of: "second")?.lowerBound)
         XCTAssertTrue(firstIndex > secondIndex)
     }
-
 }

--- a/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
+++ b/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
@@ -18,8 +18,6 @@ final class LogsTrimmerTests: XCTestCase {
         <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.086 Collect[32949:1669571] Reachability Flag Status: -R t------ reachabilityStatusForFlags</span></p>
         """
 
-        /// Store the maximum size to match the expected output.
-        let maximumSize = Int64(Data(expectedOutput.utf8).count)
         var input = expectedOutput
         input += """
         <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.101 Collect[32949:1669571] [Firebase/Crashlytics] Version 8.15.0</span></p>
@@ -42,8 +40,6 @@ final class LogsTrimmerTests: XCTestCase {
         <summary><div class="session-header"><p><span>Date: </span>2024-02-20 10:33:47</p><p><span>System: </span>iOS 16.3</p><p><span>Locale: </span>en-GB</p><p><span>Version: </span>6.2.8 (17000)</p></div></summary>
         """
 
-        /// Store the maximum size to match the expected output.
-        let maximumSize = Int64(Data(expectedOutput.utf8).count)
         var input = expectedOutput
         input += """
         <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.086 Collect[32949:1669571] Reachability Flag Status: -R t------ reachabilityStatusForFlags</span></p>

--- a/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
+++ b/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
@@ -1,0 +1,62 @@
+//
+//  LogsTrimmerTests.swift
+//  
+//
+//  Created by Antoine van der Lee on 01/03/2024.
+//
+
+import XCTest
+@testable import Diagnostics
+
+final class LogsTrimmerTests: XCTestCase {
+
+    /// It should trim the oldest line and skip session headers.
+    func testTrimmingSessionsSingleLine() {
+        let expectedOutput = """
+        <summary><div class="session-header"><p><span>Date: </span>2024-02-20 10:33:47</p><p><span>System: </span>iOS 16.3</p><p><span>Locale: </span>en-GB</p><p><span>Version: </span>6.2.8 (17000)</p></div></summary>
+        <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.086 Collect[32949:1669571] Reachability Flag Status: -R t------ reachabilityStatusForFlags</span></p>
+        """
+
+        /// Store the maximum size to match the expected output.
+        let maximumSize = Int64(Data(expectedOutput.utf8).count)
+        var input = expectedOutput
+        input += """
+        <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.101 Collect[32949:1669571] [Firebase/Crashlytics] Version 8.15.0</span></p>
+        """
+
+        var inputData = Data(input.utf8)
+        let trimmer = LogsTrimmer(
+            numberOfLinesToTrim: 1
+        )
+
+        trimmer.trim(data: &inputData)
+
+        let outputString = String(data: inputData, encoding: .utf8)
+        XCTAssertEqual(outputString, expectedOutput)
+    }
+
+    /// It should trim the oldest lines and skip session headers.
+    func testTrimmingSessionsMultipleLines() {
+        let expectedOutput = """
+        <summary><div class="session-header"><p><span>Date: </span>2024-02-20 10:33:47</p><p><span>System: </span>iOS 16.3</p><p><span>Locale: </span>en-GB</p><p><span>Version: </span>6.2.8 (17000)</p></div></summary>
+        """
+
+        /// Store the maximum size to match the expected output.
+        let maximumSize = Int64(Data(expectedOutput.utf8).count)
+        var input = expectedOutput
+        input += """
+        <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.086 Collect[32949:1669571] Reachability Flag Status: -R t------ reachabilityStatusForFlags</span></p>
+        <p class="system"><span class="log-date">2024-02-20 10:33:47</span><span class="log-separator"> | </span><span class="log-message">SYSTEM: 2024-02-20 10:33:47.101 Collect[32949:1669571] [Firebase/Crashlytics] Version 8.15.0</span></p>
+        """
+
+        var inputData = Data(input.utf8)
+        let trimmer = LogsTrimmer(
+            numberOfLinesToTrim: 10
+        )
+
+        trimmer.trim(data: &inputData)
+
+        let outputString = String(data: inputData, encoding: .utf8)
+        XCTAssertEqual(outputString, expectedOutput)
+    }
+}

--- a/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
+++ b/DiagnosticsTests/Reporters/LogsTrimmerTests.swift
@@ -4,9 +4,10 @@
 //
 //  Created by Antoine van der Lee on 01/03/2024.
 //
+//  swiftlint:disable line_length
 
-import XCTest
 @testable import Diagnostics
+import XCTest
 
 final class LogsTrimmerTests: XCTestCase {
 
@@ -60,3 +61,4 @@ final class LogsTrimmerTests: XCTestCase {
         XCTAssertEqual(outputString, expectedOutput)
     }
 }
+//  swiftlint:enable line_length

--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -223,19 +223,14 @@ extension DiagnosticsLogger {
 
         guard
             var data = try? Data(contentsOf: self.logFileLocation, options: .mappedIfSafe),
-            !data.isEmpty,
-            let newline = "\n".data(using: .utf8) else {
-                return assertionFailure("Trimming the current log file failed")
+            !data.isEmpty else {
+            return assertionFailure("Trimming the current log file failed")
         }
 
-        var position: Int = 0
-        while (logSize - Int64(position)) > (maximumSize - trimSize) {
-            guard let range = data.firstRange(of: newline, in: position ..< data.count) else { break }
-            position = range.startIndex.advanced(by: 1)
-        }
+        let trimmer = LogsTrimmer(numberOfLinesToTrim: 10)
+        trimmer.trim(data: &data)
 
-        logSize -= Int64(position)
-        data.removeSubrange(0 ..< position)
+        logSize = Int64(data.count)
 
         guard (try? data.write(to: logFileLocation, options: .atomic)) != nil else {
             return assertionFailure("Could not write trimmed log to target file location: \(logFileLocation)")

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -55,9 +55,7 @@ struct NewSession: Loggable {
         let system = "\(Device.systemName) \(Device.systemVersion)"
         let locale = Locale.preferredLanguages[0]
 
-        /// We start with `\n\n---\n\n` for backwards compatibility since it's
-        /// used for splitting the log into sections.
-        var message = "\n\n---\n\n<summary><div class=\"session-header\">"
+        var message = "<summary><div class=\"session-header\">"
         message += "<p><span>Date: </span>\(date)</p>"
         message += "<p><span>System: </span>\(system)</p>"
         message += "<p><span>Locale: </span>\(locale)</p>"

--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -55,7 +55,9 @@ struct NewSession: Loggable {
         let system = "\(Device.systemName) \(Device.systemVersion)"
         let locale = Locale.preferredLanguages[0]
 
-        var message = "<summary><div class=\"session-header\">"
+        /// We start with `\n\n---\n\n` for backwards compatibility since it's
+        /// used for splitting the log into sections.
+        var message = "\n\n---\n\n<summary><div class=\"session-header\">"
         message += "<p><span>Date: </span>\(date)</p>"
         message += "<p><span>System: </span>\(system)</p>"
         message += "<p><span>Locale: </span>\(locale)</p>"

--- a/Sources/Logging/LogsTrimmer.swift
+++ b/Sources/Logging/LogsTrimmer.swift
@@ -1,0 +1,47 @@
+//
+//  LogsTrimmer.swift
+//
+//
+//  Created by Antoine van der Lee on 01/03/2024.
+//
+
+import Foundation
+
+struct LogsTrimmer {
+    let numberOfLinesToTrim: Int
+
+    func trim(data: inout Data) {
+        guard let logs = String(data: data, encoding: .utf8) else {
+            return
+        }
+
+        // Define the regular expression pattern
+        let pattern = "<p class=\"system\"><span class=\"log-date\">(.*?)</span></p>"
+
+        // Create a regular expression object
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return
+        }
+
+        // Find all matches in the input string
+        let matches = regex.matches(
+            in: logs,
+            range: NSRange(location: 0, length: logs.utf16.count)
+        ).suffix(numberOfLinesToTrim)
+
+        guard let firstMatch = matches.first, let lastMatch = matches.last else {
+            return
+        }
+
+        let range = NSRange(
+            location: firstMatch.range.location,
+            length: lastMatch.range.upperBound - firstMatch.range.location
+        )
+        guard let range = Range(range, in: logs) else {
+            return
+        }
+
+        let trimmedLogs = logs.replacingCharacters(in: range, with: "")
+        data = Data(trimmedLogs.utf8)
+    }
+}

--- a/Sources/Logging/LogsTrimmer.swift
+++ b/Sources/Logging/LogsTrimmer.swift
@@ -24,10 +24,12 @@ struct LogsTrimmer {
         }
 
         // Find all matches in the input string
-        let matches = regex.matches(
-            in: logs,
-            range: NSRange(location: 0, length: logs.utf16.count)
-        ).suffix(numberOfLinesToTrim)
+        let matches = regex
+            .matches(
+                in: logs,
+                range: NSRange(location: 0, length: logs.utf16.count)
+            )
+            .suffix(numberOfLinesToTrim)
 
         guard let firstMatch = matches.first, let lastMatch = matches.last else {
             return


### PR DESCRIPTION
We found several broken Diagnostics reports where the HTML would not longer be valid. This turned out to be caused by our trimmer which trimmed based on byte size rather than looking at HTML components. 

This PR fixes this by removing N number of lines when the log size is too big.