### PR TITLE
Add Privacy Manifest

### DIFF
--- a/DiagnosticsTests/Reporters/AppSystemMetadataReporterTests.swift
+++ b/DiagnosticsTests/Reporters/AppSystemMetadataReporterTests.swift
@@ -20,7 +20,7 @@ final class AppSystemMetadataReporterTests: XCTestCase {
         XCTAssertEqual(metadata[AppSystemMetadataReporter.MetadataKey.appLanguage.rawValue], "en")
 
         AppSystemMetadataReporter.MetadataKey.allCases.forEach { key in
-            XCTAssertNotNil(metadata[key.rawValue])
+            XCTAssertNotNil(metadata[key.rawValue], "Metadata not found for \(key).")
         }
     }
 }

--- a/DiagnosticsTests/Reporters/AppSystemMetadataReporterTests.swift
+++ b/DiagnosticsTests/Reporters/AppSystemMetadataReporterTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import Diagnostics
+import XCTest
 
 final class AppSystemMetadataReporterTests: XCTestCase {
 
@@ -15,9 +15,18 @@ final class AppSystemMetadataReporterTests: XCTestCase {
     func testMetadata() {
         let metadata = AppSystemMetadataReporter().report().diagnostics as! [String: String]
 
-        XCTAssertEqual(metadata[AppSystemMetadataReporter.MetadataKey.appName.rawValue], Bundle.appName)
-        XCTAssertEqual(metadata[AppSystemMetadataReporter.MetadataKey.appVersion.rawValue], "\(Bundle.appVersion) (\(Bundle.appBuildNumber))")
-        XCTAssertEqual(metadata[AppSystemMetadataReporter.MetadataKey.appLanguage.rawValue], "en")
+        XCTAssertEqual(
+            metadata[AppSystemMetadataReporter.MetadataKey.appName.rawValue],
+            Bundle.appName
+        )
+        XCTAssertEqual(
+            metadata[AppSystemMetadataReporter.MetadataKey.appVersion.rawValue],
+            "\(Bundle.appVersion) (\(Bundle.appBuildNumber))"
+        )
+        XCTAssertEqual(
+            metadata[AppSystemMetadataReporter.MetadataKey.appLanguage.rawValue],
+            "en"
+        )
 
         AppSystemMetadataReporter.MetadataKey.allCases.forEach { key in
             XCTAssertNotNil(metadata[key.rawValue], "Metadata not found for \(key).")

--- a/DiagnosticsTests/Reporters/UserDefaultsReporterTests.swift
+++ b/DiagnosticsTests/Reporters/UserDefaultsReporterTests.swift
@@ -12,10 +12,29 @@ final class UserDefaultsReporterTests: XCTestCase {
 
     /// It should show the user defaults in the report.
     func testReportUserDefaults() {
-        let expectedValue = UUID().uuidString
-        UserDefaults.standard.set(expectedValue, forKey: "test_key")
-        let diagnostics = UserDefaultsReporter().report().diagnostics as! [String: Any]
-        XCTAssertEqual(diagnostics["test_key"] as? String, expectedValue)
+        let userDefaults = UserDefaults.standard
+
+        let expectedValue1 = UUID().uuidString
+        let key1 = "test_key_1"
+        userDefaults.set(expectedValue1, forKey: key1)
+
+        let expectedValue2 = UUID().uuidString
+        let key2 = "test_key_2"
+        userDefaults.set(expectedValue2, forKey: key2)
+
+        let unexpectedValue = UUID().uuidString
+        let unexpectedKey = "unexpected_key"
+        userDefaults.set(unexpectedValue, forKey: unexpectedKey)
+
+        let diagnostics = UserDefaultsReporter(
+            userDefaults: userDefaults,
+            keys: [key1, key2]
+        ).report().diagnostics as! [String: Any]
+
+        XCTAssertTrue(diagnostics.count == 2)
+        XCTAssertEqual(diagnostics[key1] as? String, expectedValue1)
+        XCTAssertEqual(diagnostics[key2] as? String, expectedValue2)
+        XCTAssertNil(diagnostics[unexpectedKey])
     }
 
 }

--- a/DiagnosticsTests/Reporters/UserDefaultsReporterTests.swift
+++ b/DiagnosticsTests/Reporters/UserDefaultsReporterTests.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2019 WeTransfer. All rights reserved.
 //
 
-import XCTest
 @testable import Diagnostics
+import XCTest
+
 final class UserDefaultsReporterTests: XCTestCase {
 
     /// It should show the user defaults in the report.
@@ -31,7 +32,7 @@ final class UserDefaultsReporterTests: XCTestCase {
             keys: [key1, key2]
         ).report().diagnostics as! [String: Any]
 
-        XCTAssertTrue(diagnostics.count == 2)
+        XCTAssertEqual(diagnostics.count, 2)
         XCTAssertEqual(diagnostics[key1] as? String, expectedValue1)
         XCTAssertEqual(diagnostics[key2] as? String, expectedValue2)
         XCTAssertNil(diagnostics[unexpectedKey])

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(name: "Diagnostics",
                             path: "Sources",
                             resources: [
                                 .process("style.css"),
-                                .process("functions.js")
+                                .process("functions.js"),
+                                .process("PrivacyInfo.xcprivacy")
                             ]),
                         .testTarget(name: "DiagnosticsTests", dependencies: ["Diagnostics"], path: "DiagnosticsTests")
                         ],

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -20,7 +20,6 @@ public enum DiagnosticsReporter {
         case appSystemMetadata
         case smartInsights
         case logs
-        case userDefaults
 
         public var reporter: DiagnosticsReporting {
             switch self {
@@ -32,8 +31,6 @@ public enum DiagnosticsReporter {
                 return SmartInsightsReporter()
             case .logs:
                 return LogsReporter()
-            case .userDefaults:
-                return UserDefaultsReporter()
             }
         }
 

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>7D9E.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -24,7 +24,10 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
         case freeSpace = "Free space"
         case deviceLanguage = "Device Language"
         case appLanguage = "App Language"
+
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         case cellularAllowed = "Cellular Allowed"
+        #endif
     }
 
     static let hardwareName: [String: String] = [

--- a/Sources/Reporters/UserDefaultsReporter.swift
+++ b/Sources/Reporters/UserDefaultsReporter.swift
@@ -11,14 +11,22 @@ import Foundation
 /// Generates a report from all the registered UserDefault keys.
 public final class UserDefaultsReporter: DiagnosticsReporting {
 
-    /// Defaults to `standard`. Can be used to override and return a different user defaults.
-    public static var userDefaults: UserDefaults = .standard
+    private let userDefaults: UserDefaults
 
-    public init() { }
+    /// All the keys that should be read from the given `UserDefaults` instance.
+    public let keys: [String]
+
+    public init(userDefaults: UserDefaults, keys: [String]) {
+        self.userDefaults = userDefaults
+        self.keys = keys
+    }
 
     public func report() -> DiagnosticsChapter {
-        let userDefaults = Self.userDefaults.dictionaryRepresentation()
-        return DiagnosticsChapter(title: "UserDefaults", diagnostics: userDefaults, formatter: Self.self)
+        let userDefaultsDiagnostics = keys.reduce(into: [:]) { dictionary, key in
+            dictionary[key] = userDefaults.object(forKey: key)
+        }
+
+        return DiagnosticsChapter(title: "UserDefaults", diagnostics: userDefaultsDiagnostics, formatter: Self.self)
     }
 }
 


### PR DESCRIPTION
This PR adds a privacy manifest file and makes a few improvements along the way.

This is a breaking change around `UserDefaultsReporter`, making sure that we are using it matching the privacy requirements. Because of these changes, `UserDefaultsReporter` is not part of the `DefaultReporter.allReporters`, requiring for users of the library to instantiate a `UserDefaultsReporter` themselves if they would like to use this reporter.

The main change is on how we're using `UserDefaultsReporter` internally to use `UserDefaults`. We decided to keep `UserDefaultsReporter` to make it less of a breaking change to the developers using `Diagnostics`, instead of removing it completely.

Before the changes, we were using the `dictionaryRepresentation()` in the `UserDefaults` instance, which would return everything contained in there. With the changes, we are now acting as wrapper, where the new API requires a `UserDefaults` instance and an array of keys that should be read from the given instance, so we iterate over the keys and fetch each of them individually. This allows us to use `C56D.1` for the `UserDefaults` reason.

For more information around the privacy manifest file, please refer to [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).

Fixes [TMOB-5314](https://wetransfer.atlassian.net/browse/TMOB-5314), #157 and #168.


[TMOB-5314]: https://wetransfer.atlassian.net/browse/TMOB-5314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ