### PR TITLE
Regex filtering for the HTML report

### DIFF
--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -157,6 +157,11 @@ extension DiagnosticsReporter {
         html += "<li><input type=\"checkbox\" id=\"system-logs\" name=\"system-logs\" checked><label for=\"system-logs\">Show system logs</label></li>"
         html += "<li><input type=\"checkbox\" id=\"error-logs\" name=\"error-logs\" checked><label for=\"error-logs\">Show error logs</label></li>"
         html += "<li><input type=\"checkbox\" id=\"debug-logs\" name=\"debug-logs\" checked><label for=\"debug-logs\">Show debug logs</label></li>"
+        html += "<li><textarea id="log-filter" placeholder="Regex" rows="3"></textarea></li>"
+        html += "<li><button id="filter-btn">Filter</button></li>"
+        html += "<li><code>Example OR: <b>error|warning</b></code></li>"
+        html += "<li><code>Example AND: <b>(?=.*error)(?=.*timeout)</b></code></li>"
+        html += "<li><code>Example Prefix: <b>^[INFO]:</b></code></li>"
         html += "</ul></nav></aside>"
         return html
     }

--- a/Sources/functions.js
+++ b/Sources/functions.js
@@ -14,7 +14,25 @@ const expandElements = shouldExpand => {
 
 function showSystemLogs(shouldShow, className) {
     document.querySelectorAll(className).forEach(function(el) {
-        if (shouldShow) {
+        el.style.display = shouldShow ? 'block' : 'none';
+    });
+}
+
+function showSystemLogsWithFilter(shouldShow, className, filterString) {
+    let regex = null;
+    if (filterString) {
+        try {
+            regex = new RegExp(filterString, 'i');
+        } catch (e) {
+            regex = null;
+        }
+    }
+    document.querySelectorAll(className).forEach(function (el) {
+        if (regex && !regex.test(el.textContent)) {
+            el.style.display = 'none';
+        } else if (filterString && !regex && !el.textContent.includes(filterString)) {
+            el.style.display = 'none';
+        } else if (shouldShow) {
             el.style.display = 'block';
         } else {
             el.style.display = 'none';
@@ -53,4 +71,11 @@ window.onload = (function () {
         showSystemLogs(false, '.error');
       }
     });
+
+    document.getElementById('filter-btn').addEventListener('click', function () {
+      var searchValue = document.getElementById('log-filter').value.trim();
+      showSystemLogsWithFilter(document.getElementById('system-logs').checked, '.system', searchValue);
+      showSystemLogsWithFilter(document.getElementById('debug-logs').checked, '.debug', searchValue);
+      showSystemLogsWithFilter(document.getElementById('error-logs').checked, '.error', searchValue);
+     });
 });

--- a/Sources/style.css
+++ b/Sources/style.css
@@ -180,6 +180,13 @@ footer {
   vertical-align: middle;
 }
 
+#log-filter {
+  width: 180px;
+  padding: 6px 8px;
+  font-size: 1em;
+  resize: vertical;
+}
+
 @media(max-width: 768px) {
   body {
     margin: 20px;


### PR DESCRIPTION
### Description
This MR introduces a Regex filtering functionality for logs.
Checkboxes are also filtering the type of logs but we can now filter logs also using Regex expressions.

### Preview
![Screenshot 2025-06-19 at 10 33 03 PM](https://github.com/user-attachments/assets/93cadc50-06f7-40e0-ae99-236bb088abcc)
