### PR TITLE
Fix tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .macOS(.v13),
         .iOS(.v16),
-        .tvOS(.v14),
+        .tvOS(.v16),
         .watchOS(.v6),
         .visionOS(.v1)],
     products: [

--- a/Sources/Device.swift
+++ b/Sources/Device.swift
@@ -50,6 +50,16 @@ enum Device {
         return Int64(space)
     }
 
+    #if os(tvOS)
+    static var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
+        guard let space = try? URL(fileURLWithPath: NSHomeDirectory() as String)
+            .resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityKey])
+            .volumeAvailableCapacity else {
+            return 0
+        }
+        return ByteCountFormatter.Units.Bytes(space)
+    }
+    #else
     static var freeDiskSpaceInBytes: ByteCountFormatter.Units.Bytes {
         guard let space = try? URL(fileURLWithPath: NSHomeDirectory() as String)
             .resourceValues(forKeys: [URLResourceKey.volumeAvailableCapacityForOpportunisticUsageKey])
@@ -58,4 +68,5 @@ enum Device {
         }
         return space
     }
+    #endif
 }


### PR DESCRIPTION
After update to v6.0.0, tvOS build is not working. This PR fixes it by:

- increasing minimum required version to tv16. This matches supported iOS version and fixes `Locale.current.region?.identifier` which is not available in previous versions.
- updates `freeDiskSpaceInBytes` to use existing methods in tvOS.