### PR TITLE
fix: add clarifying note for device machine identifiers

### DIFF
--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -19,7 +19,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
         case appName = "App name"
         case appDisplayName = "App Display Name"
         case appVersion = "App version"
-        case device = "Device (Machine ID)"
+        case device = "Device"
         case system = "System"
         case freeSpace = "Free space"
         case deviceLanguage = "Device Language"
@@ -58,10 +58,10 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
         "iPhone13,2": "iPhone 12",
         "iPhone13,3": "iPhone 12 Pro",
         "iPhone13,4": "iPhone 12 Pro Max",
-        "iPhone14,4": "iPhone 13 mini",
-        "iPhone14,5": "iPhone 13",
         "iPhone14,2": "iPhone 13 Pro",
         "iPhone14,3": "iPhone 13 Pro Max",
+        "iPhone14,4": "iPhone 13 mini",
+        "iPhone14,5": "iPhone 13",
         "iPhone14,6": "iPhone SE (3rd generation)",
         "iPhone14,7": "iPhone 14",
         "iPhone14,8": "iPhone 14 Plus",

--- a/Sources/Reporters/AppSystemMetadataReporter.swift
+++ b/Sources/Reporters/AppSystemMetadataReporter.swift
@@ -19,7 +19,7 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
         case appName = "App name"
         case appDisplayName = "App Display Name"
         case appVersion = "App version"
-        case device = "Device"
+        case device = "Device (Machine ID)"
         case system = "System"
         case freeSpace = "Free space"
         case deviceLanguage = "Device Language"
@@ -52,20 +52,45 @@ public struct AppSystemMetadataReporter: DiagnosticsReporting {
         "iPhone11,8": "iPhone XR",
         "iPhone12,1": "iPhone 11",
         "iPhone12,3": "iPhone 11 Pro",
-        "iPhone12,5": "iPhone 11 Pro Max"
+        "iPhone12,5": "iPhone 11 Pro Max",
+        "iPhone12,8": "iPhone SE (2nd generation)",
+        "iPhone13,1": "iPhone 12 mini",
+        "iPhone13,2": "iPhone 12",
+        "iPhone13,3": "iPhone 12 Pro",
+        "iPhone13,4": "iPhone 12 Pro Max",
+        "iPhone14,4": "iPhone 13 mini",
+        "iPhone14,5": "iPhone 13",
+        "iPhone14,2": "iPhone 13 Pro",
+        "iPhone14,3": "iPhone 13 Pro Max",
+        "iPhone14,6": "iPhone SE (3rd generation)",
+        "iPhone14,7": "iPhone 14",
+        "iPhone14,8": "iPhone 14 Plus",
+        "iPhone15,2": "iPhone 14 Pro",
+        "iPhone15,3": "iPhone 14 Pro Max",
+        "iPhone15,4": "iPhone 15",
+        "iPhone15,5": "iPhone 15 Plus",
+        "iPhone16,1": "iPhone 15 Pro",
+        "iPhone16,2": "iPhone 15 Pro Max",
+        "iPhone17,1": "iPhone 16 Pro",
+        "iPhone17,2": "iPhone 16 Pro Max",
+        "iPhone17,3": "iPhone 16",
+        "iPhone17,4": "iPhone 16 Plus"
     ]
 
     let title: String = "App & System Details"
     var diagnostics: [String: String] {
         var systemInfo = utsname()
         uname(&systemInfo)
-        var hardware = Mirror(reflecting: systemInfo.machine).children.reduce(into: "") { identifier, element in
+        let machineIdentifier = Mirror(reflecting: systemInfo.machine).children.reduce(into: "") { identifier, element in
             guard let value = element.value as? Int8, value != 0 else { return }
             identifier += String(UnicodeScalar(UInt8(value)))
         }
 
-        if let hardwareName = Self.hardwareName[hardware] {
-            hardware += " (\(hardwareName))"
+        let hardware: String
+        if let hardwareName = Self.hardwareName[machineIdentifier] {
+            hardware = "\(hardwareName) (Machine ID: \(machineIdentifier))"
+        } else {
+            hardware = "\(machineIdentifier) (Machine Identifier, not a version number)"
         }
 
         let system = "\(Device.systemName) \(Device.systemVersion)"


### PR DESCRIPTION
## Summary

Resolves #107.

The device machine identifier (e.g. `iPhone14,5`) can easily be confused
with iOS version numbers. This PR:

- Labels the device field as "Device (Machine ID)" to clarify its meaning
- Shows the friendly device name first, with the machine ID in parentheses
  (e.g. "iPhone 13 (Machine ID: iPhone14,5)")
- Adds a fallback note "(Machine Identifier, not a version number)" for
  unmapped hardware identifiers
- Expands the `hardwareName` dictionary with models through iPhone 16 series

