### PR TITLE
Add agent-friendly diagnostics reports

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### 7.0.0
 - NEW: Diagnostics reports are now agent-friendly single-file HTML documents with embedded structured JSON. The browser view is rendered from the JSON payload, while agents can inspect structured chapters, session metadata, log events, and crash diagnostics directly. Existing historic log sessions remain readable, and uncaught exceptions are persisted as timestamped `crash` events.
+- NEW: Diagnostics reports can now be created as standalone JSON using `DiagnosticsReporter.create(format: .json)`.
 
 ### 6.0.1
 - Add projects using Roadmap to README ([#185](https://github.com/AvdLee/Diagnostics/pull/185)) via [@AvdLee](https://github.com/AvdLee)

--- a/DiagnosticsTests/DiagnosticsReporterTests.swift
+++ b/DiagnosticsTests/DiagnosticsReporterTests.swift
@@ -31,8 +31,28 @@ final class DiagnosticsReporterTests: XCTestCase {
         let html = String(data: report.data, encoding: .utf8)!
         let document = try XCTUnwrap(html.diagnosticsReportDocument)
 
+        XCTAssertEqual(report.filename, "Diagnostics-Report.html")
+        XCTAssertEqual(report.mimeType, .html)
         XCTAssertTrue(html.contains("<script id=\"diagnostics-report-data\" type=\"application/json\">"))
         XCTAssertTrue(html.contains("<main id=\"diagnostics-report\" class=\"container\"></main>"))
+        XCTAssertEqual(document.chapters.first?.title, diagnosticsChapter.title)
+        if case .text(let value)? = document.chapters.first?.data {
+            XCTAssertEqual(value, diagnosticsChapter.diagnostics as! String)
+        } else {
+            XCTFail("Expected text diagnostics")
+        }
+    }
+
+    func testJSONGeneration() async throws {
+        let diagnosticsChapter = DiagnosticsChapter(title: UUID().uuidString, diagnostics: UUID().uuidString)
+        var reporter = MockedReporter()
+        reporter.diagnosticsChapter = diagnosticsChapter
+        let reporters = [reporter]
+        let report = await DiagnosticsReporter.create(format: .json, using: reporters)
+        let document = try JSONDecoder().decode(DiagnosticsReportDocument.self, from: report.data)
+
+        XCTAssertEqual(report.filename, "Diagnostics-Report.json")
+        XCTAssertEqual(report.mimeType, .json)
         XCTAssertEqual(document.chapters.first?.title, diagnosticsChapter.title)
         if case .text(let value)? = document.chapters.first?.data {
             XCTAssertEqual(value, diagnosticsChapter.diagnostics as! String)
@@ -96,6 +116,21 @@ final class DiagnosticsReporterTests: XCTestCase {
         let html = String(data: report.data, encoding: .utf8)!
         XCTAssertFalse(html.contains(keyToFilter))
         XCTAssertTrue(html.contains("FILTERED"))
+    }
+
+    func testJSONReportAppliesFilters() async throws {
+        let keyToFilter = UUID().uuidString
+        let mockedReport = MockedReport(diagnostics: [keyToFilter: UUID().uuidString])
+        let report = await DiagnosticsReporter.create(format: .json, using: [mockedReport], filters: [MockedFilter.self])
+        let json = String(data: report.data, encoding: .utf8)!
+        let document = try JSONDecoder().decode(DiagnosticsReportDocument.self, from: report.data)
+
+        XCTAssertFalse(json.contains(keyToFilter))
+        if case .text(let value)? = document.chapters.first?.data {
+            XCTAssertEqual(value, "FILTERED")
+        } else {
+            XCTFail("Expected filtered text diagnostics")
+        }
     }
 
     func testWithoutProvidingSmartInsightsProvider() async throws {

--- a/Example/Diagnostics-Example/ContentView+iOS.swift
+++ b/Example/Diagnostics-Example/ContentView+iOS.swift
@@ -21,19 +21,26 @@ struct ContentView_iOS: View {
             Button("Create crash") {
                 performCrash()
             }
-            Button("Send Diagnostics") {
-                Task {
-                    let report = await DiagnosticsReportFactory.make()
-                    #if targetEnvironment(simulator)
-                        /// For debugging purposes you can save the report to desktop when testing on the simulator.
-                        /// This allows you to iterate fast on your report.
-                        report.saveToDesktop()
-                    #else
-                        self.report = report
-                    #endif
-                }
+            Button("Create HTML report") {
+                createReport(format: .html)
+            }
+            Button("Create JSON report") {
+                createReport(format: .json)
             }
         }.diagnosticsReportSheet(report: $report)
+    }
+
+    private func createReport(format: DiagnosticsReport.Format) {
+        Task { @MainActor in
+            let report = await DiagnosticsReportFactory.make(format: format)
+            #if targetEnvironment(simulator)
+                /// For debugging purposes you can save the report to desktop when testing on the simulator.
+                /// This allows you to iterate fast on your report.
+                report.saveToDesktop()
+            #else
+                self.report = report
+            #endif
+        }
     }
 }
 

--- a/Example/Diagnostics-Example/ContentView+macOS.swift
+++ b/Example/Diagnostics-Example/ContentView+macOS.swift
@@ -27,16 +27,25 @@ struct ContentView_macOS: View {
             Button("Create crash") {
                 performCrash()
             }
-            Button("Send Diagnostics") {
-                report()
+            Button("Create HTML report") {
+                report(format: .html)
+            }
+            Button("Create JSON report") {
+                report(format: .json)
             }
         }
     }
     
-    private func report() {
+    private func report(format: DiagnosticsReport.Format) {
+        Task { @MainActor in
+            await createReport(format: format)
+        }
+    }
 
+    @MainActor
+    private func createReport(format: DiagnosticsReport.Format) async {
         /// Create the report.
-        let report = DiagnosticsReportFactory.make()
+        let report = await DiagnosticsReportFactory.make(format: format)
 
         guard !saveToDesktop else {
             report.saveToDesktop()
@@ -50,7 +59,7 @@ struct ContentView_macOS: View {
         service.recipients = ["support@yourcompany.com"]
         service.subject = "Diagnostics Report"
 
-        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Diagnostics-Report.html")
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(report.filename)
 
         // remove previous report
         try? FileManager.default.removeItem(at: url)

--- a/Example/Diagnostics-Example/Diagnostics/DiagnosticsReportFactory.swift
+++ b/Example/Diagnostics-Example/Diagnostics/DiagnosticsReportFactory.swift
@@ -9,7 +9,7 @@ import Diagnostics
 import Foundation
 
 struct DiagnosticsReportFactory {
-    static func make() async -> DiagnosticsReport {
+    static func make(format: DiagnosticsReport.Format = .html) async -> DiagnosticsReport {
         /// Create the report.
         var reporters = DiagnosticsReporter.DefaultReporter.allReporters
         reporters.insert(CustomReporter(), at: 1)
@@ -23,6 +23,7 @@ struct DiagnosticsReportFactory {
         reporters.insert(directoryTreesReporter, at: 2)
 
         let report = await DiagnosticsReporter.create(
+            format: format,
             using: reporters,
             filters: [
                 DiagnosticsDictionaryFilter.self,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The library allows to easily attach the Diagnostics Report as an attachment to t
     - System logs divided per session
 - [x] Possibility to filter out sensitive data using a `DiagnosticsReportFilter`
 - [x] A custom `DiagnosticsLogger` to add your own logs
-- [x] Agent-friendly single-file HTML reports with embedded structured JSON
+- [x] Agent-friendly single-file HTML reports with embedded structured JSON or standalone JSON output
 - [x] Smart insights like _"⚠️ User is low on storage"_ and *"✅ User is using the latest app version"*
 - [x] Flexible setup to add your own smart insights
 - [x] Flexible setup to add your own custom diagnostics
@@ -144,6 +144,12 @@ Diagnostics reports remain a single `.html` attachment that users can email and 
 Support agents and AI tools should parse that JSON first instead of loading the rendered HTML. The payload contains report metadata, agent hints, structured chapters, session metadata, and log events with levels like `debug`, `system`, `error`, and `crash`.
 
 The browser view is generated from this JSON. Chapters can still include `legacyHTML` when custom formatting is needed, and older on-device log sessions remain readable after users update to a newer Diagnostics version. This repository also includes a reusable analyzer skill in `diagnostics-report-analyzer-skill` for clients that support agent skills/plugins.
+
+If your support workflow consumes JSON directly, create a standalone JSON report instead:
+
+```swift
+let report = await DiagnosticsReporter.create(format: .json)
+```
 
 ### Install the Agent Skill
 

--- a/Sources/DiagnosticsReport.swift
+++ b/Sources/DiagnosticsReport.swift
@@ -10,22 +10,52 @@ import Foundation
 
 #if os(OSX)
 import AppKit
+import UniformTypeIdentifiers
 #endif
 
 /// The actual diagnostics report containing the compiled data of all reporters.
 public struct DiagnosticsReport: Sendable {
+    public enum Format: String, Sendable {
+        case html
+        case json
+
+        var defaultFilename: String {
+            "Diagnostics-Report.\(fileExtension)"
+        }
+
+        var fileExtension: String {
+            rawValue
+        }
+
+        var mimeType: MimeType {
+            switch self {
+            case .html:
+                return .html
+            case .json:
+                return .json
+            }
+        }
+    }
+
     public enum MimeType: String, Sendable {
         case html = "text/html"
+        case json = "application/json"
     }
 
     /// The file name to use for the report.
     public let filename: String
 
-    /// The MIME type of the report. Defaults to `html`.
-    public let mimeType: MimeType = .html
+    /// The MIME type of the report.
+    public let mimeType: MimeType
 
     /// The data representation of the diagnostics report.
     public let data: Data
+
+    public init(filename: String, mimeType: MimeType = .html, data: Data) {
+        self.filename = filename
+        self.mimeType = mimeType
+        self.data = data
+    }
 }
 
 public extension DiagnosticsReport {
@@ -74,7 +104,7 @@ public extension DiagnosticsReport {
         savePanel.canCreateDirectories = true
         savePanel.showsTagField = false
         savePanel.directoryURL = URL(string: initialDirectoryPath)
-        savePanel.allowedContentTypes = [.html]
+        savePanel.allowedContentTypes = [mimeType.contentType]
         savePanel.nameFieldStringValue = filename
         savePanel.title = "Save Diagnostics Report"
         savePanel.message = "Save the Diagnostics report to the chosen location."
@@ -89,3 +119,16 @@ public extension DiagnosticsReport {
     }
 #endif
 }
+
+#if os(OSX)
+private extension DiagnosticsReport.MimeType {
+    var contentType: UTType {
+        switch self {
+        case .html:
+            return .html
+        case .json:
+            return .json
+        }
+    }
+}
+#endif

--- a/Sources/DiagnosticsReporter.swift
+++ b/Sources/DiagnosticsReporter.swift
@@ -45,11 +45,13 @@ public enum DiagnosticsReporter {
     ///   Use this parameter if you'd like to exclude certain reports.
     ///   - filters: The filters to use for the generated diagnostics. Should conform to the `DiagnosticsReportFilter` protocol.
     ///   - smartInsightsProvider: Provide any smart insights for the given `DiagnosticsChapter`.
-    ///   - filename: The filename to use for the report.
-    ///   - reportTitle: The title that is used in the header of the web page of the report. Defaults to `<App Name> - Diagnostics Report`.
+    ///   - filename: The filename to use for the report. Defaults to `Diagnostics-Report.html` or `Diagnostics-Report.json` based on `format`.
+    ///   - format: The output format to use for the report. Defaults to `html`.
+    ///   - reportTitle: The title that is used in the report. Defaults to `<App Name> - Diagnostics Report`.
     /// - Returns: The generated report.
     public nonisolated(nonsending) static func create(
-        filename: String = "Diagnostics-Report.html",
+        filename: String? = nil,
+        format: DiagnosticsReport.Format = .html,
         using reporters: [DiagnosticsReporting] = DefaultReporter.allReporters,
         filters: [DiagnosticsReportFilter.Type]? = nil,
         smartInsightsProvider: SmartInsightsProviding? = nil,
@@ -85,9 +87,20 @@ public enum DiagnosticsReporter {
         }
 
         let document = DiagnosticsReportDocument(title: reportTitle, chapters: reportChapters)
-        let html = generateHTML(using: document)
-        let data = html.data(using: .utf8)!
-        return DiagnosticsReport(filename: filename, data: data)
+        let reportContent: String
+        switch format {
+        case .html:
+            reportContent = generateHTML(using: document)
+        case .json:
+            reportContent = document.json
+        }
+
+        let data = reportContent.data(using: .utf8)!
+        return DiagnosticsReport(
+            filename: filename ?? format.defaultFilename,
+            mimeType: format.mimeType,
+            data: data
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Add agent-friendly diagnostics reports backed by structured JSON, including structured log sessions/events and embedded JSON rendering for the HTML report.
- Add configurable report output so callers can create either HTML or standalone JSON via `DiagnosticsReporter.create(format:)`.
- Update docs, changelog, analyzer skill assets, and the example app with separate HTML/JSON report buttons.

## Test plan
- `swift test`
- `xcodebuild -project "Example/Diagnostics-Example.xcodeproj" -scheme "Diagnostics-Example" -destination "platform=macOS" build`
- `xcodebuild -project "Example/Diagnostics-Example.xcodeproj" -scheme "Diagnostics-Example" -destination "generic/platform=iOS Simulator" build`