### PR TITLE
Make log trimming failures nonfatal and bounded

### DIFF
--- a/DiagnosticsTests/Logging/DiagnosticsLoggerTests.swift
+++ b/DiagnosticsTests/Logging/DiagnosticsLoggerTests.swift
@@ -32,6 +32,39 @@ final class DiagnosticsLoggerTests: XCTestCase {
         XCTAssertTrue(log.contains("Uncaught Exception"))
     }
 
+    /// Exercises trimming through the logger's serial queue at the production 2 MB
+    /// limit while reads happen concurrently, mirroring report generation during
+    /// heavy logging.
+    func testTrimmingViaLoggerQueueWithConcurrentReads() throws {
+        let logFileLocation = FileManager.default.applicationSupportDirectory.appendingPathComponent("diagnostics_log.txt")
+        let maximumLogSize = 2 * 1024 * 1024
+
+        let record = SystemLog(line: "Prefilled log entry").logData
+        var prefill = Data(capacity: maximumLogSize + record.count)
+        while prefill.count <= maximumLogSize {
+            prefill.append(record)
+        }
+        try prefill.write(to: logFileLocation)
+
+        let readsFinished = expectation(description: "Concurrent reads finished")
+        DispatchQueue.global().async {
+            for _ in 0..<10 {
+                _ = try? DiagnosticsLogger.standard.readLog()
+            }
+            readsFinished.fulfill()
+        }
+
+        for index in 0..<10 {
+            DiagnosticsLogger.log(message: "Concurrent log entry \(index)")
+        }
+
+        wait(for: [readsFinished], timeout: 30)
+
+        let logData = try XCTUnwrap(DiagnosticsLogger.standard.readLog())
+        XCTAssertLessThanOrEqual(logData.count, maximumLogSize)
+        XCTAssertTrue(String(decoding: logData, as: UTF8.self).contains("Concurrent log entry 9"))
+    }
+
     #if os(macOS)
     /// On unsandboxed macOS processes (including the `swift test` runner), the Application
     /// Support directory used for the log file must be scoped by the current bundle identifier

--- a/DiagnosticsTests/Logging/LogsWriterTests.swift
+++ b/DiagnosticsTests/Logging/LogsWriterTests.swift
@@ -120,6 +120,85 @@ final class LogsWriterTests: XCTestCase {
         XCTAssertLessThan(data.count, 500)
     }
     
+    func testTrimmingReducesLargeOverflowBelowMaxSize() throws {
+        let record = SystemLog(line: "Old log Message")
+        let maximumLogSize = record.logData.count * 100
+        let writer = LogsWriter(logFileLocation: tempLogFileURL, maximumLogSize: maximumLogSize)
+
+        // Pre-fill to three times the maximum size without triggering trimming.
+        var prefill = Data()
+        while prefill.count <= maximumLogSize * 3 {
+            prefill.append(record.logData)
+        }
+        try prefill.write(to: tempLogFileURL)
+
+        // A single write should trim the file all the way below the maximum size.
+        writer.write(SystemLog(line: "New log entry"))
+
+        let data = try Data(contentsOf: tempLogFileURL)
+        XCTAssertLessThanOrEqual(data.count, maximumLogSize)
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains("New log entry"))
+    }
+
+    func testRepeatedTrimmingKeepsLogBounded() throws {
+        let record = SystemLog(line: "Repeated log entry 0")
+        let maximumLogSize = record.logData.count * 20
+        let writer = LogsWriter(logFileLocation: tempLogFileURL, maximumLogSize: maximumLogSize)
+
+        for index in 0..<100 {
+            writer.write(SystemLog(line: "Repeated log entry \(index)"))
+        }
+
+        let data = try Data(contentsOf: tempLogFileURL)
+        let contents = String(decoding: data, as: UTF8.self)
+        XCTAssertLessThanOrEqual(data.count, maximumLogSize)
+        XCTAssertTrue(contents.contains("Repeated log entry 99"))
+    }
+
+    func testWriteRecordLargerThanMaximumSizeDoesNotTrap() throws {
+        let writer = LogsWriter(logFileLocation: tempLogFileURL, maximumLogSize: 100)
+        let hugeLine = String(repeating: "A", count: 1000)
+
+        writer.write(SystemLog(line: hugeLine))
+
+        // The oversized record itself is trimmable, so the file ends up bounded
+        // instead of terminating the app with an assertion failure.
+        let data = try Data(contentsOf: tempLogFileURL)
+        XCTAssertLessThanOrEqual(data.count, 100)
+    }
+
+    func testFailingTrimDoesNotTerminateAndKeepsAppendedData() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let fileURL = directory.appendingPathComponent("locked_log.txt")
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+
+        let record = SystemLog(line: "Old log Message")
+        let maximumLogSize = record.logData.count * 10
+        var prefill = Data()
+        while prefill.count <= maximumLogSize {
+            prefill.append(record.logData)
+        }
+        try prefill.write(to: fileURL)
+
+        // Make the parent directory read-only so the atomic replacement cannot
+        // create its temporary file. The log file itself stays writable, so
+        // appending still succeeds.
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: directory.path)
+
+        let writer = LogsWriter(logFileLocation: fileURL, maximumLogSize: maximumLogSize)
+        writer.write(SystemLog(line: "New log entry"))
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
+        let contents = String(decoding: try Data(contentsOf: fileURL), as: UTF8.self)
+        XCTAssertTrue(contents.contains("New log entry"))
+    }
+
     func testLogsWriterPerformance() {
         measure {
             let tempDirectory = FileManager.default.temporaryDirectory

--- a/Sources/Logging/LogsWriter.swift
+++ b/Sources/Logging/LogsWriter.swift
@@ -6,44 +6,74 @@
 //
 
 import Foundation
+import os.log
 
 struct LogsWriter {
     let logFileLocation: URL
     let maximumLogSize: Int
-    
+
+    private static let numberOfRecordsToTrimPerBatch = 10
+
     func write(_ loggable: Loggable) {
+        let totalFileSize: UInt64
         do {
-
-            let data = loggable.logData
-
-            let fileHandle = try FileHandle(forWritingTo: logFileLocation)
-            defer {
-                try? fileHandle.close()
-            }
-            try fileHandle.seekToEnd()
-            try fileHandle.write(contentsOf: data)
-
-            let totalFileSize = try fileHandle.offset()
-            self.trimLinesIfNecessary(logSize: totalFileSize)
+            totalFileSize = try append(loggable.logData)
         } catch {
-            print("Writing data failed with error: \(error)")
+            Self.report(error, during: "appending log data")
+            return
+        }
+
+        do {
+            try trimIfNecessary(logSize: totalFileSize)
+        } catch {
+            Self.report(error, during: "trimming the log file at \(logFileLocation.path)")
         }
     }
-    
-    private func trimLinesIfNecessary(logSize: UInt64) {
+
+    /// Appends the record and returns the resulting total file size.
+    /// The file handle is closed before returning so trimming can safely
+    /// replace the file without an open handle on the same path.
+    private func append(_ data: Data) throws -> UInt64 {
+        let fileHandle = try FileHandle(forWritingTo: logFileLocation)
+        defer {
+            try? fileHandle.close()
+        }
+        try fileHandle.seekToEnd()
+        try fileHandle.write(contentsOf: data)
+        return try fileHandle.offset()
+    }
+
+    private func trimIfNecessary(logSize: UInt64) throws {
         guard logSize > maximumLogSize else { return }
 
-        guard
-            var data = try? Data(contentsOf: self.logFileLocation, options: .mappedIfSafe),
-            !data.isEmpty else {
-            return assertionFailure("Trimming the current log file failed")
+        var data = try Data(contentsOf: logFileLocation, options: .mappedIfSafe)
+        guard !data.isEmpty else { return }
+
+        let trimmer = LogsTrimmer(numberOfLinesToTrim: Self.numberOfRecordsToTrimPerBatch)
+        var didTrim = false
+        while data.count > maximumLogSize {
+            let sizeBeforeTrim = data.count
+            trimmer.trim(data: &data)
+
+            /// Stop once no trimmable records remain to prevent an infinite loop,
+            /// e.g. when the remaining content consists of untrimmable session headers.
+            guard data.count < sizeBeforeTrim else { break }
+            didTrim = true
         }
 
-        let trimmer = LogsTrimmer(numberOfLinesToTrim: 10)
-        trimmer.trim(data: &data)
+        guard didTrim else { return }
+        try data.write(to: logFileLocation, options: .atomic)
+    }
 
-        guard (try? data.write(to: logFileLocation, options: .atomic)) != nil else {
-            return assertionFailure("Could not write trimmed log to target file location: \(logFileLocation)")
+    /// Reports a failure without terminating the app and without using `print`:
+    /// stdout/stderr are piped back into the diagnostics logger, which could
+    /// recursively trigger the same failing write.
+    private static func report(_ error: Error, during operation: String) {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileWriteOutOfSpaceError {
+            os_log(.error, "Diagnostics failed %{public}@: the device is out of storage space. %{public}@", operation, nsError.description)
+        } else {
+            os_log(.error, "Diagnostics failed %{public}@: %{public}@", operation, nsError.description)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the debug-build crash `Fatal error: Could not write trimmed log to target file location: .../diagnostics_log.txt` by removing the `assertionFailure` paths in `LogsWriter` — trimming failures are now nonfatal.
- Surfaces the previously swallowed atomic-write error via `os_log` with the full `NSError` (with a dedicated message for `NSFileWriteOutOfSpaceError`, the most plausible field cause since the atomic replace needs temp space for the full trimmed file). `print` is intentionally avoided because stdout/stderr are piped back into the diagnostics logger.
- Closes the append `FileHandle` before trimming reads and atomically replaces the same file.
- Trims oversized logs fully below the configured limit in one pass instead of removing only ten records per write, which previously left the file over the limit and retried the atomic replacement on every subsequent write.

## Test plan
- [x] New regression tests: large overflow trimmed below the limit, repeated threshold crossings stay bounded, a single record larger than the limit doesn't trap, and a forced atomic-write failure (read-only parent directory) neither terminates nor loses the appended record.
- [x] New logger-level test exercising trimming through the serial queue at the production 2 MB limit with concurrent `readLog()` calls.
- [x] Full package test suite passes (56 tests, 0 failures).